### PR TITLE
Ensure that we get full list of audience members

### DIFF
--- a/src/email/mailchimp/audience.R
+++ b/src/email/mailchimp/audience.R
@@ -18,13 +18,28 @@ box::use(../../utils/country_codes)
 #'
 #' @export
 mc_members <- function() {
+  resp <- mc_member_req()
+  total_items <- resp$total_items
+  offset <- 1000
+  resp_members <- resp$members
+  while (total_items > offset) {
+    resp_members <- purrr$list_c(resp_members, mc_member_req(offset = offset)$members)
+    offset <- offset + 1000
+  }
+  resp_members
+}
+
+#' Offset member requests to the Mailchimp API
+mc_member_req <- function(offset = 0) {
   base_api$mc_api() |>
     httr2$req_url_path_append(
       "members"
     ) |>
+    httr2$req_url_query(
+      count = 1000
+    ) |>
     httr2$req_perform() |>
-    httr2$resp_body_json() |>
-    purrr$pluck("members")
+    httr2$resp_body_json()
 }
 
 #' Get interest ID list

--- a/src/email/mailchimp/custom_segmentation.R
+++ b/src/email/mailchimp/custom_segmentation.R
@@ -40,7 +40,6 @@ mc_email_segment <- function(indicator_id, iso3, test = FALSE) {
   df_ind <- dplyr$filter(df_ind, indicator_id == !!indicator_id)
   emails <- mc_subscriber_emails(
     df_ind = df_ind,
-    indicator_id = indicator_id,
     iso3 = iso3,
     test = test
   )
@@ -63,8 +62,9 @@ mc_email_segment <- function(indicator_id, iso3, test = FALSE) {
 #'
 #' Filters out members from the full Mailchimp registration, and gets their
 #' emails if they have subscribed to receive signals about a specific indicator
-#' or country.
-mc_subscriber_emails <- function(df_ind, indicator_id, iso3, test) {
+#' or country. The `df_ind` passed in must already be filtered to a specific
+#' indicator ID.
+mc_subscriber_emails <- function(df_ind, iso3, test) {
   # first we get the list of interest ids based on the iso3 codes
   regions <- unique(country_codes$iso3_to_regions(iso3))
   countries <- country_codes$iso3_to_names(iso3)


### PR DESCRIPTION
Pulling in our list of audience members, noticed after our tests today only 10 members were receiving the alerts, turns out that the default return from the Mailchimp API was 10, so have set it up so it automatically pulls in 1,000 by default and paginates through if necessary.

I have previously used `httr2::req_perform_iterative()` with iterator functions, but was too tired to figure out how to do it this time and couldn't see any link follow on in the response object, just `total_items`, so thought this was the best way, but happy for you to suggest/improve!