### PR TITLE
Align email link color with hdx-sapphire color in visualization

### DIFF
--- a/src/email/components/hdx_signals_template.html
+++ b/src/email/components/hdx_signals_template.html
@@ -213,7 +213,7 @@
 	@tip Set the styling for your email's header links. Choose a color that helps them stand out from your text.
 	*/
 		.preheaderContainer .mcnTextContent a{
-			/*@editable*/color:#1f75fe;
+			/*@editable*/color:#007ce0;
 			/*@editable*/font-weight:normal;
 			/*@editable*/text-decoration:underline;
 		}
@@ -245,7 +245,7 @@
 	@tip Set the styling for your email's header links. Choose a color that helps them stand out from your text.
 	*/
 		.headerContainer .mcnTextContent a{
-			/*@editable*/color:#1f75fe;
+			/*@editable*/color:#007ce0;
 			/*@editable*/font-weight:normal;
 			/*@editable*/text-decoration:underline;
 		}
@@ -277,7 +277,7 @@
 	@tip Set the styling for your email's body links. Choose a color that helps them stand out from your text.
 	*/
 		.bodyContainer .mcnTextContent a{
-			/*@editable*/color:#1f75fe;
+			/*@editable*/color:#007ce0;
 			/*@editable*/font-weight:normal;
 			/*@editable*/text-decoration:underline;
 		}
@@ -309,7 +309,7 @@
 	@tip Set the styling for your email's footer links. Choose a color that helps them stand out from your text.
 	*/
 		.footerContainer .mcnTextContent a{
-			/*@editable*/color:#1f75fe;
+			/*@editable*/color:#007ce0;
 			/*@editable*/font-weight:normal;
 			/*@editable*/text-decoration:underline;
 		}


### PR DESCRIPTION
Changing color of links in email HTML file to match the color in our plots, `gghdx::hdx_hex("sapphire-hdx")`. You can review since you put in the restrictions on the repo, mwahaha.