### PR TITLE
Backoff req

### DIFF
--- a/src/email/mailchimp/base_api.R
+++ b/src/email/mailchimp/base_api.R
@@ -14,7 +14,8 @@ mc_api <- function(lists_api = TRUE) {
     "https://us14.api.mailchimp.com/3.0"
   ) |>
     httr2$req_retry(
-      max_tries = 5
+      max_tries = 5,
+      backoff = \(x) 1
     ) |>
     httr2$req_auth_bearer_token(
       token = Sys.getenv("MAILCHIMP_API_KEY")

--- a/src/email/mailchimp/base_api.R
+++ b/src/email/mailchimp/base_api.R
@@ -14,8 +14,8 @@ mc_api <- function(lists_api = TRUE) {
     "https://us14.api.mailchimp.com/3.0"
   ) |>
     httr2$req_retry(
-      max_tries = 5,
-      backoff = \(x) 1
+      max_seconds = 300,
+      is_transient = \(resp) httr2$resp_status(resp) == 500
     ) |>
     httr2$req_auth_bearer_token(
       token = Sys.getenv("MAILCHIMP_API_KEY")

--- a/src/indicators/acled_conflict/utils/plot_conflict.R
+++ b/src/indicators/acled_conflict/utils/plot_conflict.R
@@ -66,7 +66,7 @@ conflict_ts <- function(df_wrangled, df_raw, title, date) {
   plot_ts$plot_ts(
     df = df_plot,
     val_col = "fatalities_30d",
-    y_axis = "Conflict fatalities (weekly)",
+    y_axis = "Conflict fatalities (monthly)",
     title = title,
     subtitle = "",
     caption = caption


### PR DESCRIPTION
Given the issues with Mailchimp servers today, implemented some simple retry logic into the API requests. Also made a quick change in ACLED plots as well because was trying to run ACLED with the retry logic during the downtime.