### PR TITLE
Fix test segmentation

### DIFF
--- a/src/alerts/create_campaigns.R
+++ b/src/alerts/create_campaigns.R
@@ -81,7 +81,7 @@ create_campaigns <- function(
       archive = FALSE,
       archive_url = unique(archive_df$campaign_url_archive),
       names_paste = "_email",
-      test = FALSE # never use browser to preview the emails using conditional logic
+      test = test
     )
   } else {
     email_df <- dplyr$tibble(

--- a/src/email/mailchimp/custom_segmentation.R
+++ b/src/email/mailchimp/custom_segmentation.R
@@ -44,6 +44,14 @@ mc_email_segment <- function(indicator_id, iso3, test = FALSE) {
     test = test
   )
 
+  # first we empty the segment before updating it
+  segments$mc_update_static_segment(
+    segment_id = df_ind$static_segment,
+    segment_name = indicator_id,
+    emails = list()
+  )
+
+  # then add back to it
   segments$mc_update_static_segment(
     segment_id = df_ind$static_segment,
     segment_name = indicator_id,


### PR DESCRIPTION
So, it turns out that updating static segments with a list of emails was not REMOVING emails already on the list. So to fix that, first need to remove the emails to make it empty, then add back the emails we want to send to.