### PR TITLE
Add output for short summary function

### DIFF
--- a/src/utils/ai_summarizer.R
+++ b/src/utils/ai_summarizer.R
@@ -35,6 +35,7 @@ ai_summarizer_without_country <- function(prompt, info, country) {
       info = ai_summary
     )
   }
+  ai_summary
 }
 
 #' AI summarizer


### PR DESCRIPTION
Quick fix, no output was being given in the case the `if()` state wasn't evaluated.