### PR TITLE
GPT-4o

### DIFF
--- a/src/alerts/create_campaigns.R
+++ b/src/alerts/create_campaigns.R
@@ -239,7 +239,7 @@ get_campaign_details <- function(indicator_id, campaign_date, test) {
     title = df_ind$indicator_subject,
     subject = paste0(
       if (test) "TEST - " else "",
-      "HDX Signals: ",
+      "Signal: ",
       df_ind$indicator_subject,
       ", ",
       formatters$format_date(Sys.Date())

--- a/src/indicators/ipc_food_insecurity/update_food_insecurity.R
+++ b/src/indicators/ipc_food_insecurity/update_food_insecurity.R
@@ -7,7 +7,6 @@ box::use(./utils/map_food_insecurity)
 box::use(./utils/info_food_insecurity)
 
 box::use(../../alerts/generate_signals[generate_signals])
-box::use(../../alerts/triage_signals[triage_signals])
 
 df_raw <- raw_food_insecurity$raw()
 df_wrangled <- wrangle_food_insecurity$wrangle(df_raw)

--- a/src/indicators/jrc_agricultural_hotspots/update_agricultural_hotspots.R
+++ b/src/indicators/jrc_agricultural_hotspots/update_agricultural_hotspots.R
@@ -6,7 +6,6 @@ box::use(./utils/info_agricultural_hotspots)
 box::use(./utils/plot_agricultural_hotspots)
 
 box::use(../../alerts/generate_signals[generate_signals])
-box::use(../../alerts/triage_signals[triage_signals])
 
 df_raw <- raw_agricultural_hotspots$raw()
 df_wrangled <- wrangle_agricultural_hotspots$wrangle(df_raw)

--- a/src/indicators/who_cholera/update_cholera.R
+++ b/src/indicators/who_cholera/update_cholera.R
@@ -5,8 +5,6 @@ box::use(./utils/plot_cholera)
 box::use(./utils/info_cholera)
 
 box::use(../../alerts/generate_signals[generate_signals])
-box::use(../../alerts/triage_signals)
-box::use(../../alerts/delete_campaign_content)
 
 # get the raw and wrangled data. The wrangled data is passed
 # to generate up the new alerts and campaigns
@@ -19,6 +17,5 @@ generate_signals(
   indicator_id = "who_cholera",
   alert_fn = alert_cholera$alert,
   plot_fn = plot_cholera$plot,
-  info_fn = info_cholera$info,
-  first_run = TRUE
+  info_fn = info_cholera$info
 )

--- a/src/utils/ai_summarizer.R
+++ b/src/utils/ai_summarizer.R
@@ -111,7 +111,7 @@ ai_summarizer <- function(prompt, info) {
 #' Call to the OpenAI API
 #'
 #' Function that insistently calls the OpenAI API in case of failure
-#' utilizing the GPT3.5 16k token model which allows for loads of context. If
+#' utilizing the GPT-4o 128,000 token model which allows for loads of context. If
 #' `gmas_test_run()` returns `TRUE`, the API is not called and `"Test output"`
 #' is returned, otherwise it returns the summarization from the API.
 insistent_ai <- purrr$insistently(
@@ -126,7 +126,7 @@ insistent_ai <- purrr$insistently(
       "Test output."
     } else {
       openai$create_chat_completion(
-        model = "gpt-4-turbo",
+        model = "gpt-4o",
         messages = list(
           list(
             "role" = "user",


### PR DESCRIPTION
Move to GPT-4o, which is the new flagship from OpenAI and also half the price as GPT-4 turbo. Also took in a couple of other edits: request to try a new title change, and removed `triage_signals()` from the update scripts.