### PR TITLE
init data_source attribution for adm0

### DIFF
--- a/src-static/update_iso3_sf.R
+++ b/src-static/update_iso3_sf.R
@@ -179,22 +179,33 @@ download_adm0_sf <- function(iso3,update_azure = TRUE) {
     download_shapefile(
       url = "https://open.africa/dataset/56d1d233-0298-4b6a-8397-d0233a1509aa/resource/76c698c9-e282-4d00-9202-42bcd908535b/download/ssd_admbnda_abyei_imwg_nbs_20180401.zip", # nolint
       layer = "ssd_admbnda_abyei_imwg_nbs_20180401",
-      data_source_abbr  = "Open Africa"
+      data_source  = "Open Africa"
     )
   } else if (iso3 == "XKX") {
     download_shapefile(
       url = "https://data.geocode.earth/wof/dist/shapefile/whosonfirst-data-admin-xk-latest.zip",
-      layer = "whosonfirst-data-admin-xk-country-polygon"
+      layer = "whosonfirst-data-admin-xk-country-polygon",
+      data_soure ="Who's On First"
     )
   } else if (iso3 == "IOT") {
-    download_shapefile("https://public.opendatasoft.com/api/explore/v2.1/catalog/datasets/world-administrative-boundaries/exports/geojson?lang=en&timezone=Europe%2FLondon") |> # nolint
+    download_shapefile(
+      url = "https://public.opendatasoft.com/api/explore/v2.1/catalog/datasets/world-administrative-boundaries/exports/geojson?lang=en&timezone=Europe%2FLondon",
+      data_source = "Opendatasoft"
+      ) |> # nolint
       dplyr$filter(
         iso3 == "IOT"
       )
+
   } else if (iso3 == "UMI") {
-    download_shapefile("https://data.geocode.earth/wof/dist/shapefile/whosonfirst-data-admin-um-latest.zip")
+    download_shapefile(
+      url = "https://data.geocode.earth/wof/dist/shapefile/whosonfirst-data-admin-um-latest.zip",
+      data_soure ="Who's On First"
+      )
   } else if (iso3 == "WLF") {
-    download_shapefile("https://pacificdata.org/data/dataset/0319bab7-4b09-4fcc-81d6-e2c2a8694078/resource/9f6d96d5-02e5-44d8-bb42-4244bde23aa5/download/wf_tsz_pol_april2022.zip") # nolint
+    download_shapefile(
+      url = "https://pacificdata.org/data/dataset/0319bab7-4b09-4fcc-81d6-e2c2a8694078/resource/9f6d96d5-02e5-44d8-bb42-4244bde23aa5/download/wf_tsz_pol_april2022.zip",
+      data_source = "Pacific Data Hub"
+      ) # nolint
   } else if (iso3 == "FJI") {
     # make sure that we shift the coordinates so it plots correctly
     download_fieldmaps_sf("FJI") |>
@@ -244,7 +255,10 @@ get_un_geodata <- function(iso3) {
 }
 
 #' Loading in module level
-sf_world <- cs$read_az_file("input/un_geodata.geojson")
+sf_world <- cs$read_az_file("input/un_geodata.geojson") |>
+  dplyr$mutate(
+    data_source = "UN Geo Hub"
+  )
 
 #' Update the centroids for ISO3
 #'

--- a/src-static/update_iso3_sf.R
+++ b/src-static/update_iso3_sf.R
@@ -197,7 +197,7 @@ download_adm0_sf <- function(iso3,update_azure = TRUE) {
   } else if (iso3 == "UMI") {
     download_shapefile(
       url = "https://data.geocode.earth/wof/dist/shapefile/whosonfirst-data-admin-um-latest.zip",
-      data_soure ="Who's On First"
+      data_source ="Who's On First"
       )
   } else if (iso3 == "WLF") {
     download_shapefile(

--- a/src-static/update_iso3_sf.R
+++ b/src-static/update_iso3_sf.R
@@ -72,7 +72,8 @@ simplify_adm0 <- function(iso3){
   # have to extract geometries from collections
   if (sf$st_geometry_type(sf_union) == "GEOMETRYCOLLECTION") {
     sf_union <- sf$st_collection_extract(sf_union) |>
-      sf$st_union()
+      dplyr$group_by(data_source) |>
+      dplyr$summarise(do_union = TRUE)
   }
 
   # simply in projected coordinates
@@ -99,11 +100,8 @@ simplify_adm0 <- function(iso3){
 #'
 #' @returns Filtered `sf_adm0`
 filter_adm0_sf <- function(sf_adm0, iso3) {
-  if (iso3 == "CHL") {
-    sf_adm0 <- dplyr$filter(
-      sf_adm0,
-      !(ADM3_PCODE %in% c("CL05201", "CL05104")) # dropping Isla de Pascua and Juan Fernández
-    )
+  if (iso3 == "CHL"){
+    sf_adm0 <- st_crop_adj_bbox(sf_adm0, xmin = 33.73339)
   } else if (iso3 == "BMU") {
     sf_adm0 <- st_crop_adj_bbox(sf_adm0, ymax = -0.05)
   } else if (iso3 == "CRI") {
@@ -136,7 +134,7 @@ filter_adm0_sf <- function(sf_adm0, iso3) {
 #' Gets the bbox for an `sf` object, and then adjusts it based on the parameters
 #' based in, then crops the `sf`.
 #'
-#' @param sf_obj Simple featuer object
+#' @param sf_obj Simple feature object
 #' @param xmin Amount to adjust xmin
 #' @param xmax Amount to adjust xmax
 #' @param ymin Amount to adjust ymin

--- a/src-static/update_iso3_sf.R
+++ b/src-static/update_iso3_sf.R
@@ -43,13 +43,13 @@ update_adm0_sf <- function(iso3) {
     filter_adm0_sf(iso3)
 
   sf_union <- suppressMessages(
-      sf_adm0 |>
-        # keepig it tidy allows us to retain cols
-        # i might even suggest mutating iso3 and grouping
-        # that in so it's also included in the file
-        dplyr$group_by(data_source) |>
-        dplyr$summarise(do_union=TRUE)
-    )
+    sf_adm0 |>
+      # keepig it tidy allows us to retain cols
+      # i might even suggest mutating iso3 and grouping
+      # that in so it's also included in the file
+      dplyr$group_by(data_source) |>
+      dplyr$summarise(do_union = TRUE)
+  )
   # i did some speed benchmarking this against sf$st_union() and they are equivalent in speed.
 
   # have to extract geometries from collections

--- a/src-static/update_iso3_sf.R
+++ b/src-static/update_iso3_sf.R
@@ -43,9 +43,14 @@ update_adm0_sf <- function(iso3) {
     filter_adm0_sf(iso3)
 
   sf_union <- suppressMessages(
-    sf$st_union(sf_adm0) |>
-      sf$st_as_sf() # so we can check number of rows
-  )
+      sf_adm0 |>
+        # keepig it tidy allows us to retain cols
+        # i might even suggest mutating iso3 and grouping
+        # that in so it's also included in the file
+        dplyr$group_by(data_source) |>
+        dplyr$summarise(do_union=TRUE)
+    )
+  # i did some speed benchmarking this against sf$st_union() and they are equivalent in speed.
 
   # have to extract geometries from collections
   if (sf$st_geometry_type(sf_union) == "GEOMETRYCOLLECTION") {
@@ -157,7 +162,8 @@ download_adm0_sf <- function(iso3) {
   } else if (iso3 == "AB9") {
     download_shapefile(
       url = "https://open.africa/dataset/56d1d233-0298-4b6a-8397-d0233a1509aa/resource/76c698c9-e282-4d00-9202-42bcd908535b/download/ssd_admbnda_abyei_imwg_nbs_20180401.zip", # nolint
-      layer = "ssd_admbnda_abyei_imwg_nbs_20180401"
+      layer = "ssd_admbnda_abyei_imwg_nbs_20180401",
+      data_source_label = "Open Africa"
     )
   } else if (iso3 == "XKX") {
     download_shapefile(
@@ -195,7 +201,8 @@ download_adm0_sf <- function(iso3) {
 download_fieldmaps_sf <- function(iso3) {
   iso3 <- tolower(iso3)
   download_shapefile(
-    url = glue$glue("https://data.fieldmaps.io/cod/originals/{iso3}.gpkg.zip")
+    url = glue$glue("https://data.fieldmaps.io/cod/originals/{iso3}.gpkg.zip"),
+    data_source_label = "FieldMaps, geoBoundaries, U.S. Department of State, U.S. Geological Survey"
   )
 }
 

--- a/src/utils/download_shapefile.R
+++ b/src/utils/download_shapefile.R
@@ -16,10 +16,11 @@ box::use(dplyr)
 #' @returns sf object
 #'
 #' @export
-download_shapefile <- function(url,
-                               layer = NULL,
-                               data_source_label = NULL
-                               ) {
+download_shapefile <- function(
+  url,
+  layer = NULL,
+  data_source_label = NULL
+) {
   if (stringr$str_ends(url, ".zip")) {
     utils$download.file(
       url = url,
@@ -60,7 +61,7 @@ download_shapefile <- function(url,
       quiet = TRUE
     )
   }
-  if(!is.null(data_source_label)){
+  if (!is.null(data_source_label)) {
     ret <- ret |>
       dplyr$mutate(
         data_source = data_source_label

--- a/src/utils/download_shapefile.R
+++ b/src/utils/download_shapefile.R
@@ -2,8 +2,7 @@ box::use(stringr)
 box::use(utils)
 box::use(tools)
 box::use(sf)
-box::use(dplyr)
-options(timeout = 1000)
+
 #' Download shapefile and read
 #'
 #' Download shapefile to temp file, unzipping zip files if necessary. Deals with zipped
@@ -12,6 +11,9 @@ options(timeout = 1000)
 #'
 #' @param url URL to download
 #' @param layer Layer to read
+#' @param data_source `character` name of data_source. If supplied a column named "data_source"
+#'     will added to sf object with the specified data_source input. If NULL (default)
+#'     no column added.
 #'
 #' @returns sf object
 #'
@@ -62,10 +64,7 @@ download_shapefile <- function(
     )
   }
   if (!is.null(data_source)) {
-    ret <- ret |>
-      dplyr$mutate(
-        data_source = data_source
-      )
+    ret$data_source <- data_source
   }
   ret
 }

--- a/src/utils/download_shapefile.R
+++ b/src/utils/download_shapefile.R
@@ -3,7 +3,7 @@ box::use(utils)
 box::use(tools)
 box::use(sf)
 box::use(dplyr)
-
+options(timeout=1000)
 #' Download shapefile and read
 #'
 #' Download shapefile to temp file, unzipping zip files if necessary. Deals with zipped
@@ -17,9 +17,9 @@ box::use(dplyr)
 #'
 #' @export
 download_shapefile <- function(
-  url,
-  layer = NULL,
-  data_source_label = NULL
+    url,
+    layer = NULL,
+    data_source = NULL
 ) {
   if (stringr$str_ends(url, ".zip")) {
     utils$download.file(
@@ -61,11 +61,11 @@ download_shapefile <- function(
       quiet = TRUE
     )
   }
-  if (!is.null(data_source_label)) {
+  if (!is.null(data_source)) {
     ret <- ret |>
       dplyr$mutate(
-        data_source = data_source_label
+        data_source = data_source
       )
   }
-  return(ret)
+  ret
 }

--- a/src/utils/download_shapefile.R
+++ b/src/utils/download_shapefile.R
@@ -2,6 +2,7 @@ box::use(stringr)
 box::use(utils)
 box::use(tools)
 box::use(sf)
+box::use(dplyr)
 
 #' Download shapefile and read
 #'
@@ -15,7 +16,10 @@ box::use(sf)
 #' @returns sf object
 #'
 #' @export
-download_shapefile <- function(url, layer = NULL) {
+download_shapefile <- function(url,
+                               layer = NULL,
+                               data_source_label = NULL
+                               ) {
   if (stringr$str_ends(url, ".zip")) {
     utils$download.file(
       url = url,
@@ -45,15 +49,22 @@ download_shapefile <- function(url, layer = NULL) {
   }
 
   if (!is.null(layer)) {
-    sf$st_read(
+    ret <- sf$st_read(
       fn,
       layer = layer,
       quiet = TRUE
     )
   } else {
-    sf$st_read(
+    ret <- sf$st_read(
       fn,
       quiet = TRUE
     )
   }
+  if(!is.null(data_source_label)){
+    ret <- ret |>
+      dplyr$mutate(
+        data_source = data_source_label
+      )
+  }
+  return(ret)
 }

--- a/src/utils/download_shapefile.R
+++ b/src/utils/download_shapefile.R
@@ -3,7 +3,7 @@ box::use(utils)
 box::use(tools)
 box::use(sf)
 box::use(dplyr)
-options(timeout=1000)
+options(timeout = 1000)
 #' Download shapefile and read
 #'
 #' Download shapefile to temp file, unzipping zip files if necessary. Deals with zipped
@@ -17,9 +17,9 @@ options(timeout=1000)
 #'
 #' @export
 download_shapefile <- function(
-    url,
-    layer = NULL,
-    data_source = NULL
+  url,
+  layer = NULL,
+  data_source = NULL
 ) {
   if (stringr$str_ends(url, ".zip")) {
     utils$download.file(


### PR DESCRIPTION
Not actually ready to be merged, but I thought rather than write a bunch of words in issue #111 , easier to just to just write some starter code in a branch to help discuss the approach. Happy to completely adjust approach and/or delete branch as we see fit.

You'll see I just implemented the approach for the Fieldmaps admin 0s as well as the first exception `iso3=ABA` (just put in a placeholder attribution for ABA). If we think it makes sense i can manually enter the attributions for the rest of the exceptions.

Will need to adjust this code potentially as/if we address #114 as well, but it should work in current construction of updating admins