### PR TITLE
Align CRON timings

### DIFF
--- a/.github/workflows/monitor_agricultural_hotspots.yaml
+++ b/.github/workflows/monitor_agricultural_hotspots.yaml
@@ -34,7 +34,7 @@ on:
             - "WARNING"
             - "ERROR"
     schedule:
-      - cron: "0 11 * * 1-5"
+      - cron: "0 8 * * 1-5"
 
 jobs:
     run:
@@ -50,7 +50,7 @@ jobs:
           GMAS_TEST_RUN: ${{ inputs.GMAS_TEST_RUN || 'FALSE' }}
           FIRST_RUN: ${{ inputs.FIRST_RUN || 'FALSE' }}
           LOG_LEVEL: ${{ inputs.LOG_LEVEL || 'INFO'}}
-        steps:   
+        steps:
             - name: Checkout repository
               uses: actions/checkout@v3
 

--- a/.github/workflows/monitor_conflict.yaml
+++ b/.github/workflows/monitor_conflict.yaml
@@ -34,7 +34,7 @@ on:
             - "WARNING"
             - "ERROR"
     schedule:
-      - cron: "0 11 * * 2"
+      - cron: "0 8 * * 2"
 
 jobs:
     run:
@@ -52,7 +52,7 @@ jobs:
           FIRST_RUN: ${{ inputs.FIRST_RUN || 'FALSE' }}
           HS_TEST: ${{ inputs.HS_TEST || 'FALSE' }}
           LOG_LEVEL: ${{ inputs.LOG_LEVEL || 'INFO' }}
-        steps:   
+        steps:
             - name: Checkout repository
               uses: actions/checkout@v3
 

--- a/.github/workflows/monitor_displacement.yaml
+++ b/.github/workflows/monitor_displacement.yaml
@@ -34,7 +34,7 @@ on:
             - "WARNING"
             - "ERROR"
     schedule:
-      - cron: "0 11 * * 2"
+      - cron: "0 8 * * 2"
 
 jobs:
     run:
@@ -51,7 +51,7 @@ jobs:
           FIRST_RUN: ${{ inputs.FIRST_RUN || 'FALSE' }}
           HS_TEST: ${{ inputs.HS_TEST || 'FALSE' }}
           LOG_LEVEL: ${{ inputs.LOG_LEVEL || 'INFO' }}
-        steps:   
+        steps:
             - name: Checkout repository
               uses: actions/checkout@v3
 

--- a/.github/workflows/monitor_food_insecurity.yaml
+++ b/.github/workflows/monitor_food_insecurity.yaml
@@ -34,7 +34,7 @@ on:
             - "WARNING"
             - "ERROR"
     schedule:
-      - cron: "0 11 * * 1-5"
+      - cron: "0 8 * * 1-5"
 
 jobs:
     run:
@@ -51,7 +51,7 @@ jobs:
           FIRST_RUN: ${{ inputs.FIRST_RUN || 'FALSE' }}
           HS_TEST: ${{ inputs.HS_TEST || 'FALSE' }}
           LOG_LEVEL: ${{ inputs.LOG_LEVEL || 'DEBUG' }}
-        steps:   
+        steps:
             - name: Checkout repository
               uses: actions/checkout@v3
 


### PR DESCRIPTION
For HDX Signals, we are running CRON jobs on the IPC API, similar to the workflow [here](https://github.com/OCHA-DAP/hdx-scraper-ipc). Godfrey flagged that we had previously sent a signal for the IPC that was not reflected on HDX until the next day because we have not aligned the timing of our CRON jobs.

Our runs are currently on [weekdays at 11 UTC](https://github.com/OCHA-DAP/hdx-signals/blob/6cae30ad969398d9e94aea93872e5bedd88390b0/.github/workflows/monitor_food_insecurity.yaml#L37), while the HDX scraper is [every day at 8:10 UTC](https://github.com/OCHA-DAP/hdx-scraper-ipc/blob/0267f52f9728f7ac7315cf903a34261ee738b2bd/.github/workflows/run-python-script.yml#L8).

Given that we want to have time to review alerts with Sarah, I thought might be best to start our runs at 8UTC, which will be just before the workday begins for most of us in UK/CET time and give sufficient review time to send alerts before working day is out in most areas we work, and for the morning time in the USA. This would also ensure that we also run prior to the IPC scraper so no issues of alignment will occur there. For other datasets:

1. JRC ASAP, we are checking HDX data, which is [updated at midnight UTC](https://github.com/OCHA-DAP/hdx-scraper-asap/blob/3407c8f8d52ac0845682b49cebfac8430981d2cb/.github/workflows/run-python-script.yaml#L8) so will be aligned there.
2. IDMC IDU is run at [19:45 UTC](https://github.com/OCHA-DAP/hdx-scraper-idmc-idu/blob/34b943f4297359d3dccae3c685c8051ecd90959d/.github/workflows/run-python-script.yml#L8), so there is a risk of misalignment. Will raise issue in rep to check about this.
3. ACLED, the scraper repo I could find is archived, so will ask Mike what the current setup is there.
4. WFP market monitor, we will be using HDX, so no misalignment there.