### PR TITLE
Adjust text to match IDMC flow language

### DIFF
--- a/src/indicators/idmc_displacement/utils/plot_displacement.R
+++ b/src/indicators/idmc_displacement/utils/plot_displacement.R
@@ -26,7 +26,7 @@ plot <- function(df_alerts, df_wrangled, df_raw, preview = FALSE) {
     dplyr$mutate(
       title = paste0(
         scales$label_comma()(round(value)),
-        " people displaced due to ",
+        " internal displacements due to ",
         displacement_cause,
         " since ",
         formatters$format_date(date - lubridate$days(30))


### PR DESCRIPTION
Simple change to IDMC plot tile based on feedback from the IDMC. Changes to match the IDMC language on flow monitoring vs stocks found [here](https://www.internal-displacement.org/monitoring-tools/#:~:text=The%20total%20number%20of%20movements,conflict%20or%20violence%20or%20disaster).