### PR TITLE
Hotfix to IDMC because hardcoded indicator_id incorrect

### DIFF
--- a/src/indicators/idmc_displacement/update_displacement.R
+++ b/src/indicators/idmc_displacement/update_displacement.R
@@ -15,7 +15,6 @@ box::use(../../utils/hs_logger)
 
 test <- as.logical(Sys.getenv("HS_TEST", unset = FALSE))
 test_filter <- if (test) c("AFG", "SSD") else NULL
-indicator_id <- "idmc_displacement_conflict"
 
 hs_logger$configure_logger()
 hs_logger$monitoring_log_setup(indicator_id)
@@ -27,7 +26,7 @@ df_wrangled <- wrangle_displacement$wrangle(df_raw)
 df_conflict <- generate_signals(
   df_wrangled = dplyr$filter(df_wrangled, displacement_type == "Conflict"),
   df_raw = dplyr$filter(df_raw, displacement_type == "Conflict"),
-  indicator_id = indicator_id,
+  indicator_id = "idmc_displacement_conflict",
   alert_fn = alert_displacement$alert,
   plot_fn = plot_displacement$plot,
   info_fn = info_displacement$info,
@@ -40,7 +39,7 @@ df_conflict <- generate_signals(
 df_disaster <- generate_signals(
   df_wrangled = dplyr$filter(df_wrangled, displacement_type == "Disaster"),
   df_raw = dplyr$filter(df_raw, displacement_type == "Disaster"),
-  indicator_id = indicator_id,
+  indicator_id = "idmc_displacement_disaster",
   alert_fn = alert_displacement$alert,
   plot_fn = plot_displacement$plot,
   info_fn = info_displacement$info,

--- a/src/indicators/idmc_displacement/utils/map_displacement.R
+++ b/src/indicators/idmc_displacement/utils/map_displacement.R
@@ -55,7 +55,7 @@ map <- function(df_alerts, df_wrangled, df_raw, preview = FALSE) {
 displacement_map <- function(df_wrangled, df_raw, title, date) {
   caption <- paste(
     "Data from the IDMC, http://www.internal-displacement.org",
-    paste("Accessed", formatters$format_date(Sys.Date())),
+    paste("Created", formatters$format_date(Sys.Date())),
     country_codes$iso3_to_names(unique(df_wrangled$iso3)),
     sep = "\n"
   )


### PR DESCRIPTION
Hardcoded `indicator_id` meant that both disaster related displacement and conflict related displacement were being assigned to conflict related.