### PR TITLE
Remove overwrite_content functionality

### DIFF
--- a/src/alerts/check_existing_signals.R
+++ b/src/alerts/check_existing_signals.R
@@ -18,22 +18,19 @@ box::use(../utils/gmas_test_run)
 #'
 #' @param indicator_id ID of the indicator
 #' @param first_run Whether or not this is the first run
-#' @param overwrite_content Whether or not to overwrite the content of existing rows
-#'     in a `signals.parquet` file, rather than generating a new one.
 #' @param fn_signals File name of the Signals data
 #' @param test Whether or not this is for testing signals development. If `TRUE`,
 #'     errors are not generated if data is in the overall `output/signals.parquet`
 #'     file, so we can test efficiently.
 #'
 #' @export
-check_existing_signals <- function(indicator_id, first_run, overwrite_content, fn_signals, test) {
+check_existing_signals <- function(indicator_id, first_run, fn_signals, test) {
   if (gmas_test_run$gmas_test_run()) {
     return(invisible(NULL))
   }
 
   check_ind_signals(
     indicator_id = indicator_id,
-    overwrite_content = overwrite_content,
     fn_signals = fn_signals
   )
 
@@ -48,10 +45,9 @@ check_existing_signals <- function(indicator_id, first_run, overwrite_content, f
 #' Check indicator signals file
 #'
 #' Checks the indicator signals file, `fn_signals`, and throws error if there
-#' are existing rows in `output/{indicator}/signals.parquet` file and
-#' `overwrite_content` is `FALSE`, or if there are no rows and `overwrite_content`
-#' is `TRUE`.
-check_ind_signals <- function(indicator_id, overwrite_content, fn_signals) {
+#' are existing rows in `output/{indicator}/signals.parquet` file since that
+#' must be triaged before overwriting.
+check_ind_signals <- function(indicator_id, fn_signals) {
   if (fn_signals %in% az_files) {
     num_ind_signals <- nrow(cs$read_az_file(fn_signals))
   } else {
@@ -60,7 +56,7 @@ check_ind_signals <- function(indicator_id, overwrite_content, fn_signals) {
 
 
   # generate an error if the indicator signals are non-empty
-  if (num_ind_signals > 0 && !overwrite_content) {
+  if (num_ind_signals > 0) {
     stop(
       stringr$str_wrap(
         paste0(
@@ -69,27 +65,7 @@ check_ind_signals <- function(indicator_id, overwrite_content, fn_signals) {
           " signals data ",
           fn_signals,
           " on Azure is non-empty. Please triage this data into `output/signals.parquet` ",
-          "prior to generating new signals by running `triage_signals()`. ",
-          "If you want to re-create content on this ",
-          "existing dataset, then you should run ",
-          "`generate_signals(..., overwrite_content = TRUE)`."
-        )
-      ),
-      call. = FALSE
-    )
-  }
-
-  # generate an error if the indicator signals is empty but we said `overwrite_content = TRUE`
-  if (num_ind_signals == 0 && overwrite_content) {
-    stop(
-      stringr$str_wrap(
-        paste0(
-          "The ",
-          indicator_id,
-          " signals data ",
-          fn_signals,
-          " on Azure is empty. You specified `overwrite_content = TRUE` but there ",
-          "is no existing alerts or content to overwrite. "
+          "prior to generating new signals by running `triage_signals()`. "
         )
       ),
       call. = FALSE

--- a/src/alerts/delete_campaign_content.R
+++ b/src/alerts/delete_campaign_content.R
@@ -25,50 +25,39 @@ box::use(./template_data)
 delete_campaign_content <- function(df) {
   # first, split out other images if present
   if ("other_images_ids" %in% names(df) && any(!is.na(df$other_images_ids))) {
-    df <- tidyr$separate_wider_delim(
+    df_delete <- tidyr$separate_wider_delim(
       data = df,
       cols = other_images_ids,
       delim = ";",
       names_sep = "_",
       too_few = "align_start"
     )
+  } else {
+    df_delete <- df
   }
 
   # get all file ids from the data frame and delete them
   delete_ids(
-    df = df,
+    df = df_delete,
     cols = c("plot_id", "map_id", "plot2_id", dplyr$starts_with("other_images_id")),
     object_type = "file"
   )
 
   # delete the templates
   delete_ids(
-    df = df,
+    df = df_delete,
     cols = dplyr$starts_with("template_id"),
     object_type = "template"
   )
   # delete the campaigns
   delete_ids(
-    df = df,
+    df = df_delete,
     cols = dplyr$starts_with("campaign_id"),
     object_type = "campaign"
   )
 
-  # now drop all the columns and return the data frame of alerts
-  # only do this if available
-  if (all(c("iso3", "value") %in% names(df))) {
-    df_delete <- dplyr$bind_cols(
-      template_data$campaign_content_template,
-      template_data$campaign_template |>
-        dplyr$select(-iso3, -date)
-    )
-    df |>
-      dplyr$select(
-        -dplyr$any_of(
-          names(df_delete)
-        )
-      )
-  }
+  # return empty input data frame
+  df[0, ]
 }
 
 #' Deletes all IDs found in specified columns

--- a/src/alerts/generate_signals.R
+++ b/src/alerts/generate_signals.R
@@ -44,9 +44,6 @@ hs_logger$configure_logger()
 #'     done by splitting the campaigns dataset by data and generating alerts
 #'     across each date individually. If it is not the first run, then the
 #'     entire alerts data frame is converted into a single campaign during monitoring.
-#' @param overwrite_content Overwrite existing content in the indicator signals.
-#'     This is to be used when we don't want to generate new alerts, but want to
-#'     fix something in the campaign content itself.
 #' @param test Whether or not to generate the signals for testing (defaults to
 #'     `FALSE`. If `TRUE`, only a limited number of alerts are generated, based
 #'     on the `test_filter` argument. If `GMAS_TEST_RUN` is `TRUE`, previews are
@@ -73,7 +70,6 @@ generate_signals <- function(
     summary_fn = NULL,
     info_fn = NULL,
     first_run = FALSE,
-    overwrite_content = FALSE,
     test = FALSE,
     test_filter = NULL) {
   # file name differs if testing or not
@@ -87,32 +83,23 @@ generate_signals <- function(
   check_existing_signals(
     indicator_id = indicator_id,
     first_run = first_run,
-    overwrite_content = overwrite_content,
     fn_signals = fn_signals,
     test = test
   )
 
   # generate the new alerts that will receive a campaign
-  if (!overwrite_content) {
-    # filter out the data before generating new alerts
-    df_alerts <- df_wrangled |>
-      filter_test_data(
-        test = test,
-        test_filter = test_filter
-      ) |>
-      alert_fn() |>
-      generate_alerts(
-        indicator_id = indicator_id,
-        first_run = first_run,
-        test = test
-      )
-  } else {
-    # use existing alerts, and just delete the campaign content from Mailchimp and re-create
-    # we don't filter the wrangled data here because no need to, we already
-    # should have a limited set of alerts
-    df_alerts <- cs$read_az_file(fn_signals) |>
-      delete_campaign_content()
-  }
+  # filter out the data before generating new alerts
+  df_alerts <- df_wrangled |>
+    filter_test_data(
+      test = test,
+      test_filter = test_filter
+    ) |>
+    alert_fn() |>
+    generate_alerts(
+      indicator_id = indicator_id,
+      first_run = first_run,
+      test = test
+    )
 
   # return empty data frame if alerts is empty
   if (nrow(df_alerts) == 0) {

--- a/src/alerts/triage_signals.R
+++ b/src/alerts/triage_signals.R
@@ -22,9 +22,8 @@ box::use(../utils/get_env[get_env])
 #' - `DELETE` the campaign content, which will delete the campaign content but
 #' leave the alerts information. This is so you don't recalculate when we would
 #' signal, just the visuals and other campaign information in the email. This will
-#' delete all campaign content from Mailchimp and then remove those columns from
-#' `output/{indicator_id}/signals.parquet`. You will have to run
-#' `generate_signals(..., overwrite_content = TRUE)`.
+#' delete all campaign content from Mailchimp and then delete all of the rows
+#' from `output/{indicator_id}/signals.parquet`.
 #'
 #' - `Any other user input`: Do nothing, in which you can decide later manually what to do, and use
 #' `delete_campaign_content()` or `send_signals()` yourself manually.
@@ -174,8 +173,8 @@ approve_signals <- function(df, fn_signals, test) {
         )
       )
       if (new_input == "DELETE") {
-        delete_campaign_content(df)
-        cs$update_az_file(df[0, ], fn_signals)
+        df_deleted <- delete_campaign_content(df)
+        cs$update_az_file(df_deleted, fn_signals)
       } else {
         message(
           "You have not deleted the content in ",
@@ -189,9 +188,6 @@ approve_signals <- function(df, fn_signals, test) {
   } else if (user_command == "DELETE") {
     # replace the campaign content with the deleted stuff
     df_deleted <- delete_campaign_content(df)
-    if (test) {
-      df_deleted <- df_deleted[0, ]
-    }
 
     cs$update_az_file(
       df = df_deleted,


### PR DESCRIPTION
Previously, `overwrite_content` was a confusing parameter that when passed, meant that you expected existing rows of data in the signals data frame, and you would use those rows to generate new campaign content and signals. That is, you could basically not recalculate when you alert, just adjust how the content looked.

Turns out, this was way too complex, especially since recalculating when we want to alert is simple and easy and local, whereas the expensive computations are already in the content generation side. I've thus removed all of this functionality, and instead we just expect that if a dataset exists in `output/indicator/signals.parquet`, that it must be triaged before any new runs can happen. And if we elect to delete during triage, instead of deleting the content columns, it removes all rows so the entire data needs to be recreated. Much simpler this way I think.