### PR TITLE
Slack integration

### DIFF
--- a/.github/workflows/post_slack_update.yaml
+++ b/.github/workflows/post_slack_update.yaml
@@ -1,0 +1,23 @@
+name: Post Slack update
+
+on:
+  schedule:
+    - cron: "0 13 * * 1-5"
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN}}
+      HS_SLACK_URL: ${{ secrets.HS_SLACK_URL}}
+      HS_TEST: ${{ 'FALSE' }}
+    steps: 
+        - name: Checkout repository
+          uses: actions/checkout@v3
+
+        - name: Set up environment
+          uses: ocha-dap/hdx-signals-actions@07b3181e914ef100bd9c8134f3c7a13383870b9d
+
+        - name: Run R monitoring script
+          shell: bash
+          run: Rscript ./src/alerts/check_signals_updates.R

--- a/.github/workflows/post_slack_update.yaml
+++ b/.github/workflows/post_slack_update.yaml
@@ -2,7 +2,7 @@ name: Post Slack update
 
 on:
   schedule:
-    - cron: "0 13 * * 1-5"
+    - cron: "0 10 * * 1-5"
 
 jobs:
   run:
@@ -18,6 +18,6 @@ jobs:
         - name: Set up environment
           uses: ocha-dap/hdx-signals-actions@07b3181e914ef100bd9c8134f3c7a13383870b9d
 
-        - name: Run R monitoring script
+        - name: Create Slack message
           shell: bash
           run: Rscript ./src/alerts/check_signals_updates.R

--- a/check-actions.R
+++ b/check-actions.R
@@ -1,0 +1,115 @@
+library(httr)
+library(jsonlite)
+box::use(src/utils/get_env[get_env])
+box::use(logger[log_error])
+box::use(src/utils/hs_logger)
+box::use(src/alerts/triage_signals[get_signals_df])
+
+hs_logger$configure_logger()
+
+org_name <- "ocha-dap"
+repo_name <- "hdx-signals"
+base_logs_url <- "https://github.com/OCHA-DAP/hdx-signals/actions/runs/"
+indicators_path <- "src/indicators"
+indicators <- list.files(indicators_path)[file.info(file.path(indicators_path, list.files(indicators_path)))$isdir]
+test <- Sys.getenv("TEST", unset = "FALSE")
+
+process_run_status <- function(response, ind, base_logs_url) {
+  if (status_code(response) == 200) {
+    content <- content(response, as = "text", encoding = "UTF-8")
+    json_data <- fromJSON(content, flatten = TRUE)
+    df_runs <- as.data.frame(json_data)
+    df_runs$date <- as.Date(df_runs$workflow_runs.created_at)
+
+    # Get today's scheduled runs from the main branch
+    df_sel <- subset(
+      df_runs,
+      workflow_runs.event == "schedule" &
+        workflow_runs.head_branch == "main" &
+        date == Sys.Date()
+    )
+
+    # Handle cases
+    if (nrow(df_sel) == 1) {
+      status <- df_sel[1, ]$workflow_runs.conclusion
+      run_id <- df_sel[1, ]$workflow_runs.id
+      if (status == "failure") {
+        run_link <- paste0(base_logs_url, run_id)
+        status_update <- paste0(":red_circle: ", ind, ": Failed update - <", run_link, "|Check logs> \n")
+      } else if (status == "success") {
+        status_update <- paste0(":large_green_circle: ", ind, ": Successful update \n")
+      }
+    } else if (nrow(df_sel) == 0) {
+      status_update <- paste0(":heavy_minus_sign: ", ind, ": No scheduled update \n")
+    } else {
+      status_update <- paste0(":red_circle: ", ind, ": More than one scheduled run today \n")
+    }
+  } else {
+    status_update <- paste0(":red_circle: ", ind, ": Failed request for workflow status - ", status_code(response), "\n")
+  }
+
+  return(status_update)
+}
+
+gh_status <- function(ind, org_name, repo_name) {
+  # TODO Temp cleaning before workflows are renamed to match indicator ids
+  ind <- sub("^[^_]*_", "", ind)
+  workflow_id <- paste0("monitor_", ind, ".yaml")
+  token <- get_env("GH_TOKEN")
+  url <- paste0("https://api.github.com/repos/", org_name, "/", repo_name, "/actions/workflows/", workflow_id, "/runs")
+  response <- GET(url, add_headers(Authorization = paste("token", token)))
+  return(response)
+}
+
+post_slack_message <- function(status_text) {
+  msg <- list(
+    blocks = list(
+      list(
+        type = "section",
+        text = list(
+          type = "plain_text",
+          text = paste0(Sys.Date(), ": No signals identified"),
+          emoji = TRUE
+        )
+      ),
+      list(type = "divider"),
+      list(
+        type = "context",
+        elements = list(
+          list(
+            type = "mrkdwn",
+            text = status_text
+          )
+        )
+      ),
+      list(type = "divider")
+    )
+  )
+  json_body <- toJSON(msg, pretty = TRUE, auto_unbox = TRUE)
+  response <- POST(get_env("SLACK_URL"), body = json_body, encode = "json")
+  if (response$status != 200) {
+    log_error("Error posting Slack message")
+    stop()
+  }
+}
+
+full_status <- ""
+for (ind in indicators) {
+  print(ind)
+  gh_response <- gh_status(ind, org_name, repo_name)
+  workflow_status <- process_run_status(gh_response, ind, base_logs_url)
+  full_status <- paste0(full_status, workflow_status)
+}
+
+post_slack_message(full_status)
+
+for (ind in indicators) {
+    fn_signals <- paste0(
+        "output/",
+        ind,
+        if (test) "/test" else "",
+        "/signals.parquet"
+    )
+
+    df <- get_signals_df(fn_signals)
+}

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -51,9 +51,13 @@ slack_post_message <- function(header_text, status_text, signals_text) {
       list(type = "divider")
     )
   )
-  json_body <- jsonlite$toJSON(msg, pretty = TRUE, auto_unbox = TRUE)
-  response <- POST(get_env("SLACK_URL"), body = json_body, encode = "json")
-  if (response$status != 200) {
+
+  # Create and perform the POST request using httr2
+  response <- httr2$request(get_env("SLACK_URL")) |>
+    httr2$req_body_json(msg) |>
+    httr2$req_perform()
+
+  if (response$status_code != 200) {
     logger$log_error("Error posting Slack message")
     stop()
   }

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -102,13 +102,12 @@ slack_build_header <- function(n_signals) {
 
 #' Builds the signal alert text
 #'
-#' @param iso3 Country iso3 code
 #' @param indicator_id Indicator ID
-#' @param campaign_url URL of Mailchimp campaign to review
+#' @param df DataFrame with all the signals for the given indicator
 #'
 #' @returns String signal alert text
-slack_build_alert <- function(iso3, indicator_id, campaign_url) {
-  return(paste0(iso3, ": ", indicator_id, " <", campaign_url, " | See draft campaign>\n"))
+slack_build_alert <- function(indicator_id, df) {
+  paste0("*", indicator_id, "* - ", nrow(df), " countries impacted- <", df$campaign_url_archive[1], " | See draft campaign>\n")
 }
 
 #' Takes the response from a GitHub Actions run of a single indicator
@@ -206,16 +205,10 @@ for (ind in indicators) {
   )
   df <- cs$read_az_file(fn_signals)
   if (nrow(df) > 0) {
-    for (i in seq_len(nrow(df))) {
-      row <- df[i, ]
-      alert <- slack_build_alert(
-        row["iso3"],
-        row["indicator_name"],
-        row["campaign_url_email"]
-      )
-      signals <- paste0(signals, alert)
-    }
-    n_signals <- n_signals + nrow(df)
+    logger$log_info(paste0("Found signal for ", ind))
+    alert <- slack_build_alert(ind, df)
+    signals <- paste0(signals, alert)
+    n_signals <- n_signals + 1
   }
 }
 logger$log_info(paste0("Found ", n_signals, " signals"))

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -119,11 +119,11 @@ slack_build_alert <- function(iso3, indicator_id, campaign_url) {
 #'
 #' @returns String status message to be posted to Slack
 slack_build_workflow_status <- function(indicator_id) {
-  workflow_id <- paste0("monitor_", ind, ".yaml")
+  workflow_id <- paste0("monitor_", indicator_id, ".yaml")
   base_logs_url <- paste0("https://github.com/ocha-dap/hdx-signals/actions/runs/")
 
-  tryCatch({
-    df_runs <- httr2$request(
+  df_runs <- tryCatch({
+    httr2$request(
       "https://api.github.com/repos/ocha-dap/hdx-signals/actions/workflows"
     ) |>
     httr2$req_url_path_append(
@@ -140,15 +140,18 @@ slack_build_workflow_status <- function(indicator_id) {
   },
   error = function(e) {
     logger$log_error(e$message)
+    e$message
+  })
+
+  if (is.character(df_runs)) {
     return(paste0(
       ":red_circle: ",
       ind,
-      ": Failed request for workflow status - ",
-      e$message,
+      ": Failed request for workflow status -",
+      df_runs,
       "\n"
     ))
-  })
-
+  }
   # Get today's scheduled runs from the main branch
   df_runs$date <- as.Date(df_runs$workflow_runs.created_at)
   df_sel <- subset(

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -83,12 +83,12 @@ slack_post_message <- function(header_text, status_text, signals_text) {
 #'
 #' @returns String header text
 slack_build_header <- function(n_signals) {
-    if (n_signals == 0) {
-        title <- paste0(Sys.Date(), ": No signals identified")
-    } else {
-        title <- paste0(":rotating_light: <!channel> ", Sys.Date(), ": ", n_signals, " alerts identified")
-    }
-    return(title)
+  if (n_signals == 0) {
+    title <- paste0(Sys.Date(), ": No signals identified")
+  } else {
+    title <- paste0(":rotating_light: <!channel> ", Sys.Date(), ": ", n_signals, " alerts identified")
+  }
+  return(title)
 }
 
 #' Builds the signal alert text
@@ -187,13 +187,13 @@ for (ind in indicators_azure) {
     "/signals.parquet"
   )
   df <- cs$read_az_file(fn_signals)
-  if(nrow(df) > 0) {
-      for (i in 1:nrow(df)) {
+  if (nrow(df) > 0) {
+    for (i in seq_len(nrow(df))) {
       row <- df[i, ]
       alert <- slack_build_alert(
-          row["iso3"],
-          row["indicator_name"],
-          row["campaign_url_email"]
+        row["iso3"],
+        row["indicator_name"],
+        row["campaign_url_email"]
       )
       signals <- paste0(signals, alert)
     }

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -11,33 +11,6 @@ box::use(cs = ../utils/cloud_storage)
 
 hs_logger$configure_logger()
 
-
-#' Queries the GitHub API to get all runs from a given monitoring workflow
-#' Requires workflows to be named following this convention: `monitor_<indicator_id>.yaml`
-#'
-#' NOTE: More data will be returned as each workflow is run more times. Perhaps won't scale well,
-#' depending on how many runs a workflow will have
-#'
-#' @param indicator_id ID of the indicator
-#'
-#' @returns JSON API response
-gh_status <- function(indicator_id) {
-  # TODO Temp cleaning before workflows are renamed to match indicator ids
-  ind <- sub("^[^_]*_", "", indicator_id)
-  workflow_id <- paste0("monitor_", ind, ".yaml")
-  httr2$request(
-    "https://api.github.com/repos/ocha-dap/hdx-signals/actions/workflows"
-  ) |>
-  httr2$req_url_path_append(
-    workflow_id,
-    "runs"
-  ) |>
-  httr2$req_auth_bearer_token(
-    token = get_env("GH_TOKEN")
-  ) |>
-  httr2$req_perform() # can use httr2$req_method("GET") if not defaulting to GET, although I think it should
-}
-
 #' Builds and posts a message to Slack, using incoming webhooks
 #' See API docs: https://api.slack.com/messaging/webhooks
 #'
@@ -113,7 +86,6 @@ slack_build_alert <- function(indicator_id, df) {
 #' Takes the response from a GitHub Actions run of a single indicator
 #' and outputs a status message to be posted to Slack
 #'
-#' @param response JSON payload returned from `gh_status`
 #' @param indicator_id ID of the indicator
 #'
 #' @returns String status message to be posted to Slack

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -1,83 +1,51 @@
-box::use(jsonlite)
-box::use(httr)
+box::use(jsonlite[fromJSON, toJSON])
+box::use(httr[GET, POST, add_headers, status_code, content])
 box::use(purrr)
-box::use(src/utils/get_env[get_env])
-box::use(logger[log_error])
-box::use(src/utils/hs_logger)
-box::use(cs = src/utils/cloud_storage)
+box::use(logger[log_error, log_info])
+
+box::use(../utils/get_env[get_env])
+box::use(../utils/hs_logger)
+box::use(cs = ../utils/cloud_storage)
 
 hs_logger$configure_logger()
 
-org_name <- "ocha-dap"
-repo_name <- "hdx-signals"
-indicators_path <- "src/indicators"
-indicators <- list.files(indicators_path)[file.info(file.path(indicators_path, list.files(indicators_path)))$isdir]
-test <- Sys.getenv("TEST", unset = "FALSE")
-test <- FALSE
 
-process_run_status <- function(response, ind) {
-  base_logs_url <- paste0("https://github.com/", org_name, "/", repo_name, "/actions/runs/")
-
-  if (status_code(response) == 200) {
-    content <- content(response, as = "text", encoding = "UTF-8")
-    json_data <- fromJSON(content, flatten = TRUE)
-    df_runs <- as.data.frame(json_data)
-    df_runs$date <- as.Date(df_runs$workflow_runs.created_at)
-
-    # Get today's scheduled runs from the main branch
-    df_sel <- subset(
-      df_runs,
-      workflow_runs.event == "schedule" &
-        workflow_runs.head_branch == "main" &
-        date == Sys.Date()
-    )
-
-    # Handle cases
-    if (nrow(df_sel) == 1) {
-      status <- df_sel[1, ]$workflow_runs.conclusion
-      run_id <- df_sel[1, ]$workflow_runs.id
-      if (status == "failure") {
-        run_link <- paste0(base_logs_url, run_id)
-        status_update <- paste0(":red_circle: ", ind, ": Failed update - <", run_link, "|Check logs> \n")
-      } else if (status == "success") {
-        status_update <- paste0(":large_green_circle: ", ind, ": Successful update \n")
-      }
-    } else if (nrow(df_sel) == 0) {
-      status_update <- paste0(":heavy_minus_sign: ", ind, ": No scheduled update \n")
-    } else {
-      status_update <- paste0(":red_circle: ", ind, ": More than one scheduled run today \n")
-    }
-  } else {
-    status_update <- paste0(
-      ":red_circle: ",
-      ind,
-      ": Failed request for workflow status - ",
-      status_code(response),
-      "\n"
-    )
-  }
-
-  return(status_update)
-}
-
-gh_status <- function(ind, org_name, repo_name) {
+#' Queries the GitHub API to get all runs from a given monitoring workflow
+#' Requires workflows to be named following this convention: `monitor_<indicator_id>.yaml`
+#'
+#' NOTE: More data will be returned as each workflow is run more times. Perhaps won't scale well,
+#' depending on how many runs a workflow will have
+#'
+#' @param indicator_id ID of the indicator
+#'
+#' @returns JSON API response
+gh_status <- function(indicator_id) {
   # TODO Temp cleaning before workflows are renamed to match indicator ids
-  ind <- sub("^[^_]*_", "", ind)
+  ind <- sub("^[^_]*_", "", indicator_id)
   workflow_id <- paste0("monitor_", ind, ".yaml")
   token <- get_env("GH_TOKEN")
-  url <- paste0("https://api.github.com/repos/", org_name, "/", repo_name, "/actions/workflows/", workflow_id, "/runs")
+  url <- paste0("https://api.github.com/repos/ocha-dap/hdx-signals/actions/workflows/", workflow_id, "/runs")
   response <- GET(url, add_headers(Authorization = paste("token", token)))
   return(response)
 }
 
-slack_post_message <- function(header, status_text, signals) {
+#' Builds and posts a message to Slack, using incoming webhooks
+#' See API docs: https://api.slack.com/messaging/webhooks
+#'
+#' @param header_text Text for the message header
+#' @param status_text Text for the GitHub actions status report
+#' @param signals_text Text for the signals status report
+#'
+#' @returns Nothing. Message is posted to slack and will log an error if not successful
+slack_post_message <- function(header_text, status_text, signals_text) {
+  # See https://app.slack.com/block-kit-builder for prototyping layouts in JSON
   msg <- list(
     blocks = list(
       list(
         type = "section",
         text = list(
           type = "plain_text",
-          text = header,
+          text = header_text,
           emoji = TRUE
         )
       ),
@@ -85,7 +53,7 @@ slack_post_message <- function(header, status_text, signals) {
         type = "section",
         text = list(
           type = "mrkdwn",
-          text = signals
+          text = signals_text
         )
       ),
       list(type = "divider"),
@@ -101,35 +69,98 @@ slack_post_message <- function(header, status_text, signals) {
       list(type = "divider")
     )
   )
-
-  json_body <- jsonlite$toJSON(msg, pretty = TRUE, auto_unbox = TRUE)
-
+  json_body <- toJSON(msg, pretty = TRUE, auto_unbox = TRUE)
   response <- POST(get_env("SLACK_URL"), body = json_body, encode = "json")
   if (response$status != 200) {
-    print(response)
     log_error("Error posting Slack message")
     stop()
   }
 }
 
-slack_build_header <- function(n_alerts) {
-    if (n_alerts == 0) {
+#' Builds the header text, depending on how many signals are reported
+#'
+#' @param n_signals Number of signals reported
+#'
+#' @returns String header text
+slack_build_header <- function(n_signals) {
+    if (n_signals == 0) {
         title <- paste0(Sys.Date(), ": No signals identified")
     } else {
-        title <- paste0(":rotating_light: <!channel> ", Sys.Date(), ": ", n_alerts, " alerts identified")
+        title <- paste0(":rotating_light: <!channel> ", Sys.Date(), ": ", n_signals, " alerts identified")
     }
     return(title)
 }
 
-slack_build_alert <- function(iso3, ind, campaign_url) {
-  return(paste0(iso3, ": ", ind, " <", campaign_url, " | See draft campaign>\n"))
+#' Builds the signal alert text
+#'
+#' @param iso3 Country iso3 code
+#' @param indicator_id Indicator ID
+#' @param campaign_url URL of Mailchimp campaign to review
+#'
+#' @returns String signal alert text
+slack_build_alert <- function(iso3, indicator_id, campaign_url) {
+  return(paste0(iso3, ": ", indicator_id, " <", campaign_url, " | See draft campaign>\n"))
 }
 
+#' Takes the response from a GitHub Actions run of a single indicator
+#' and outputs a status message to be posted to Slack
+#'
+#' @param response JSON payload returned from `gh_status`
+#' @param indicator_id ID of the indicator
+#'
+#' @returns String status message to be posted to Slack
+slack_build_workflow_status <- function(response, indicator_id) {
+  base_logs_url <- paste0("https://github.com/ocha-dap/hdx-signals/actions/runs/")
 
+  if (status_code(response) == 200) {
+    content <- content(response, as = "text", encoding = "UTF-8")
+    json_data <- fromJSON(content, flatten = TRUE)
+    df_runs <- as.data.frame(json_data)
+    df_runs$date <- as.Date(df_runs$workflow_runs.created_at)
+
+    # Get today's scheduled runs from the main branch
+    df_sel <- subset(
+      df_runs,
+      workflow_runs.event == "schedule" &
+        workflow_runs.head_branch == "main" &
+        date == Sys.Date()
+    )
+
+    if (nrow(df_sel) == 1) {
+      status <- df_sel[1, ]$workflow_runs.conclusion
+      run_id <- df_sel[1, ]$workflow_runs.id
+      if (status == "failure") {
+        run_link <- paste0(base_logs_url, run_id)
+        status_update <- paste0(":red_circle: ", indicator_id, ": Failed update - <", run_link, "|Check logs> \n")
+      } else if (status == "success") {
+        status_update <- paste0(":large_green_circle: ", indicator_id, ": Successful update \n")
+      }
+      # If no scheduled runs happened off of main today
+    } else if (nrow(df_sel) == 0) {
+      status_update <- paste0(":heavy_minus_sign: ", indicator_id, ": No scheduled update \n")
+    } else {
+      status_update <- paste0(":red_circle: ", indicator_id, ": More than one scheduled run today \n")
+    }
+  } else {
+    status_update <- paste0(
+      ":red_circle: ",
+      ind,
+      ": Failed request for workflow status - ",
+      status_code(response),
+      "\n"
+    )
+  }
+
+  return(status_update)
+}
+
+indicators_path <- "src/indicators"
+indicators <- list.files(indicators_path)[file.info(file.path(indicators_path, list.files(indicators_path)))$isdir]
 full_status <- ""
 n_signals <- 0
 signals <- ""
-# TODO: Hard coding this because the IDMC names don't totally match the indicator_ids
+
+# TODO: Hard coding this because the monitoring scripts don't totally match the indictor ids
 indicators_azure <- c(
   "acled_conflict",
   "idmc_displacement_conflict",
@@ -138,8 +169,17 @@ indicators_azure <- c(
   "jrc_agricultural_hotspots"
 )
 
+log_info("Checking GitHub Actions status...")
+for (ind in indicators) {
+  gh_response <- gh_status(ind)
+  workflow_status <- slack_build_workflow_status(gh_response, ind)
+  full_status <- paste0(full_status, workflow_status)
+}
+log_info("Successfully checked")
+
+log_info("Checking for signals across all indicators...")
 for (ind in indicators_azure) {
-  print(ind)
+  test <- Sys.getenv("TEST", unset = TRUE)
   fn_signals <- paste0(
     "output/",
     ind,
@@ -157,24 +197,11 @@ for (ind in indicators_azure) {
       )
       signals <- paste0(signals, alert)
     }
-
     n_signals <- n_signals + nrow(df)
-
   }
-
 }
-
-
-for (ind in indicators) {
-  gh_response <- gh_status(ind, org_name, repo_name)
-  workflow_status <- process_run_status(gh_response, ind)
-  full_status <- paste0(full_status, workflow_status)
-}
+log_info(paste0("Found ", n_signals, " signals"))
 
 header <- slack_build_header(n_signals)
-
-print(n_signals)
-
-
-
 slack_post_message(header, full_status, signals)
+log_info("Successfully posted message to Slack")

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -26,9 +26,8 @@ slack_post_message <- function(header_text, status_text, signals_text) {
       list(
         type = "section",
         text = list(
-          type = "plain_text",
-          text = header_text,
-          emoji = TRUE
+          type = "mrkdwn",
+          text = header_text
         )
       ),
       list(

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -178,12 +178,7 @@ for (ind in indicators) {
   logger$log_info("Successfully checked")
 
   logger$log_info(paste0("Checking for signals: ", ind, "..."))
-  fn_signals <- paste0(
-    "output/",
-    ind,
-    if (test) "/test" else "",
-    "/signals.parquet"
-  )
+  fn_signals <- cs$signals_path(ind, test)
   df <- cs$read_az_file(fn_signals)
   if (nrow(df) > 0) {
     logger$log_info(paste0("Found signal for ", ind))

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -3,6 +3,7 @@ box::use(httr2)
 box::use(purrr)
 box::use(logger)
 box::use(stringr)
+box::use(dplyr)
 
 box::use(../utils/get_env[get_env])
 box::use(../utils/hs_logger)
@@ -142,11 +143,11 @@ slack_build_workflow_status <- function(indicator_id) {
   }
   # Get today's scheduled runs from the main branch
   df_runs$date <- as.Date(df_runs$workflow_runs.created_at)
-  df_sel <- subset(
+  df_sel <- dplyr$filter(
     df_runs,
-    workflow_runs.event == "schedule" &
-      workflow_runs.head_branch == "main" &
-      date == Sys.Date()
+    workflow_runs.event == "schedule",
+    workflow_runs.head_branch == "main",
+    date == Sys.Date()
   )
 
   if (nrow(df_sel) == 1) {

--- a/src/alerts/check_signals_updates.R
+++ b/src/alerts/check_signals_updates.R
@@ -151,9 +151,9 @@ slack_build_workflow_status <- function(indicator_id) {
   )
 
   if (nrow(df_sel) == 1) {
-    status <- df_sel[1, ]$workflow_runs.conclusion
+    status <- df_sel$workflow_runs.conclusion
     if (status == "failure") {
-      run_id <- df_sel[1]$workflow_runs.id
+      run_id <- df_sel$workflow_runs.id
       run_link <- paste0(base_logs_url, run_id)
       paste0(":red_circle: ", indicator_id, ": Failed update - <", run_link, "|Check logs> \n")
     } else if (status == "success") {

--- a/src/alerts/generate_signals.R
+++ b/src/alerts/generate_signals.R
@@ -77,12 +77,7 @@ generate_signals <- function(
     test = FALSE,
     test_filter = NULL) {
   # file name differs if testing or not
-  fn_signals <- paste0(
-    "output/",
-    indicator_id,
-    if (test) "/test" else "",
-    "/signals.parquet"
-  )
+  fn_signals <- cs$signals_path(indicator_id, test)
 
   check_existing_signals(
     indicator_id = indicator_id,

--- a/src/alerts/triage_signals.R
+++ b/src/alerts/triage_signals.R
@@ -52,13 +52,7 @@ box::use(../utils/get_env[get_env])
 #'
 #' @export
 triage_signals <- function(indicator_id, n_campaigns = 10, test = FALSE) {
-  fn_signals <- paste0(
-    "output/",
-    indicator_id,
-    if (test) "/test" else "",
-    "/signals.parquet"
-  )
-
+  fn_signals <- cs$signals_path(indicator_id, test)
   df <- get_signals_df(fn_signals)
   preview_signals(df = df, n_campaigns = n_campaigns)
   approve_signals(df = df, fn_signals = fn_signals, test = test)

--- a/src/alerts/triage_signals.R
+++ b/src/alerts/triage_signals.R
@@ -67,6 +67,7 @@ triage_signals <- function(indicator_id, n_campaigns = 10, test = FALSE) {
 #' Check the signals data frame
 #'
 #' Checks the signals data frame, and if it is non-empty, returns it.
+#' @export
 get_signals_df <- function(fn_signals) {
   # check that there signals to triage
   if (fn_signals %in% cs$az_file_detect()) {

--- a/src/alerts/triage_signals.R
+++ b/src/alerts/triage_signals.R
@@ -67,7 +67,6 @@ triage_signals <- function(indicator_id, n_campaigns = 10, test = FALSE) {
 #' Check the signals data frame
 #'
 #' Checks the signals data frame, and if it is non-empty, returns it.
-#' @export
 get_signals_df <- function(fn_signals) {
   # check that there signals to triage
   if (fn_signals %in% cs$az_file_detect()) {

--- a/src/utils/cloud_storage.R
+++ b/src/utils/cloud_storage.R
@@ -175,6 +175,23 @@ azure_endpoint_url <- function(service = c("blob", "file"), stage = c("prod", "d
   glue$glue(dsci_az_endpoint)
 }
 
+#' Builds the path of the signals.parquet files
+#'
+#' @param indicator_id ID of the indicator
+#' @param test Whether looking for the test file or not
+#'
+#' @returns String path
+#'
+#' @export
+signals_path <- function(indicator_id, test) {
+  paste0(
+    "output/",
+    indicator_id,
+    if (test) "/test" else "",
+    "/signals.parquet"
+  )
+}
+
 # gets the Dsci blob endpoints using the HDX Signals SAS
 blob_endpoint_dev <- az$blob_endpoint(
   endpoint = azure_endpoint_url("blob", "dev"),


### PR DESCRIPTION
This PR introduces new functionality to output daily Slack updates on whether any new signals were detected and on the status of the monitoring scripts running in GitHub Actions. See screenshot below for examples of what these messages will look like, or #hdx-signals-bot-testing. 

Closes #64. 

If there are signals: 

<img width="551" alt="Screenshot 2024-05-29 at 12 27 45 PM" src="https://github.com/OCHA-DAP/hdx-signals/assets/25990216/019d467c-765b-4a2c-b3d7-9d445cc40ce1">

If there are no signals: 

<img width="417" alt="Screenshot 2024-05-29 at 11 57 53 AM" src="https://github.com/OCHA-DAP/hdx-signals/assets/25990216/9bf6dc93-0ed7-4cde-bebe-d13fcf21f86e">

