### PR TITLE
Hotfix signals return

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,2 +1,5 @@
 source("renv/activate.R")
-options(warn = 2)
+
+if (!interactive()) {
+  options(warn = 2)
+}

--- a/src/alerts/generate_signals.R
+++ b/src/alerts/generate_signals.R
@@ -179,7 +179,10 @@ generate_signals <- function(
     df_campaigns,
     fn_signals
   )
+
   log_info(paste0("Monitoring completed. ", nrow(df_campaigns), " signals generated for ", indicator_id))
+
+  df_campaigns
 }
 
 #' Validate campaigns data

--- a/src/alerts/triage_signals.R
+++ b/src/alerts/triage_signals.R
@@ -180,7 +180,7 @@ approve_signals <- function(df, fn_signals, test) {
         message(
           "You have not deleted the content in ",
           fn_signals,
-          " or removed the content from Mailchimp.\n Remember to do so in the",
+          " or removed the content from Mailchimp.\n Remember to do so in the ",
           "future.",
           call. = FALSE
         )

--- a/src/alerts/triage_signals.R
+++ b/src/alerts/triage_signals.R
@@ -134,7 +134,7 @@ preview_campaign_urls <- function(campaign_urls) {
 #' @param fn_signals File name to the signals data
 #' @param test Whether or not the signals were for testing.
 approve_signals <- function(df, fn_signals, test) {
-  user_name <- get_env("HDX_SIGNALS_ADMIN_NAME")
+  user_name <- get_env("HS_ADMIN_NAME")
 
   user_command <- readline(
     paste0(

--- a/src/alerts/triage_signals.R
+++ b/src/alerts/triage_signals.R
@@ -140,7 +140,7 @@ approve_signals <- function(df, fn_signals, test) {
     paste0(
       "Tell us what you want to do with the following commands:\n\n",
       "APPROVE: Send campaigns",
-      if (test) "\n" else "and add to `output/signals.parquet`\n",
+      if (test) "\n" else " and add to `output/signals.parquet`\n",
       "DELETE: Delete the campaign content, so you can recreate later.\n",
       "Any other input: Do nothing, so you can decide later."
     )

--- a/src/indicators/acled_conflict/update_conflict.R
+++ b/src/indicators/acled_conflict/update_conflict.R
@@ -24,7 +24,7 @@ df_raw <- raw_conflict$raw()
 df_wrangled <- wrangle_conflict$wrangle(df_raw)
 
 # now generate signals
-generate_signals(
+df_conflict <- generate_signals(
   df_wrangled = df_wrangled,
   df_raw = df_raw,
   indicator_id = indicator_id,

--- a/src/indicators/acled_conflict/update_conflict.R
+++ b/src/indicators/acled_conflict/update_conflict.R
@@ -12,7 +12,7 @@ box::use(./utils/summary_conflict)
 box::use(../../alerts/generate_signals[generate_signals])
 box::use(../../utils/hs_logger)
 
-test <- as.logical(Sys.getenv("HS_TEST", unset = FALSE))
+test <- as.logical(Sys.getenv("HS_TEST", unset = TRUE))
 test_filter <- if (test) c("AFG", "SSD") else NULL
 indicator_id <- "acled_conflict"
 

--- a/src/indicators/idmc_displacement/update_displacement.R
+++ b/src/indicators/idmc_displacement/update_displacement.R
@@ -13,8 +13,9 @@ box::use(./utils/map_displacement)
 box::use(../../alerts/generate_signals[generate_signals])
 box::use(../../utils/hs_logger)
 
-test <- as.logical(Sys.getenv("HS_TEST", unset = FALSE))
+test <- as.logical(Sys.getenv("HS_TEST", unset = TRUE))
 test_filter <- if (test) c("AFG", "SSD") else NULL
+indicator_id <- "idmc_displacement_conflict"
 
 hs_logger$configure_logger()
 hs_logger$monitoring_log_setup(indicator_id)
@@ -26,7 +27,7 @@ df_wrangled <- wrangle_displacement$wrangle(df_raw)
 df_conflict <- generate_signals(
   df_wrangled = dplyr$filter(df_wrangled, displacement_type == "Conflict"),
   df_raw = dplyr$filter(df_raw, displacement_type == "Conflict"),
-  indicator_id = "idmc_displacement_conflict",
+  indicator_id = indicator_id,
   alert_fn = alert_displacement$alert,
   plot_fn = plot_displacement$plot,
   info_fn = info_displacement$info,
@@ -39,7 +40,7 @@ df_conflict <- generate_signals(
 df_disaster <- generate_signals(
   df_wrangled = dplyr$filter(df_wrangled, displacement_type == "Disaster"),
   df_raw = dplyr$filter(df_raw, displacement_type == "Disaster"),
-  indicator_id = "idmc_displacement_disaster",
+  indicator_id = indicator_id,
   alert_fn = alert_displacement$alert,
   plot_fn = plot_displacement$plot,
   info_fn = info_displacement$info,

--- a/src/indicators/idmc_displacement/update_displacement.R
+++ b/src/indicators/idmc_displacement/update_displacement.R
@@ -13,8 +13,9 @@ box::use(./utils/map_displacement)
 box::use(../../alerts/generate_signals[generate_signals])
 box::use(../../utils/hs_logger)
 
-test <- as.logical(Sys.getenv("HS_TEST", unset = TRUE))
+test <- as.logical(Sys.getenv("HS_TEST", unset = FALSE))
 test_filter <- if (test) c("AFG", "SSD") else NULL
+
 indicator_id <- "idmc_displacement_conflict"
 
 hs_logger$configure_logger()
@@ -36,6 +37,11 @@ df_conflict <- generate_signals(
   test = test,
   test_filter = test_filter
 )
+
+# Disaster data
+
+indicator_id <- "idmc_displacement_disaster"
+hs_logger$monitoring_log_setup(indicator_id)
 
 df_disaster <- generate_signals(
   df_wrangled = dplyr$filter(df_wrangled, displacement_type == "Disaster"),

--- a/src/indicators/ipc_food_insecurity/update_food_insecurity.R
+++ b/src/indicators/ipc_food_insecurity/update_food_insecurity.R
@@ -11,7 +11,7 @@ box::use(./utils/info_food_insecurity)
 box::use(../../alerts/generate_signals[generate_signals])
 box::use(../../utils/hs_logger)
 
-test <- as.logical(Sys.getenv("HS_TEST", unset = FALSE))
+test <- as.logical(Sys.getenv("HS_TEST", unset = TRUE))
 test_filter <- if (test) c("AFG", "SSD") else NULL
 indicator_id <- "ipc_food_insecurity"
 

--- a/src/indicators/jrc_agricultural_hotspots/update_agricultural_hotspots.R
+++ b/src/indicators/jrc_agricultural_hotspots/update_agricultural_hotspots.R
@@ -21,7 +21,7 @@ df_raw <- raw_agricultural_hotspots$raw()
 df_wrangled <- wrangle_agricultural_hotspots$wrangle(df_raw)
 
 # now generate signals
-generate_signals(
+df_jrc <- generate_signals(
   df_wrangled = df_wrangled,
   indicator_id = indicator_id,
   alert_fn = alert_agricultural_hotspots$alert,

--- a/src/indicators/jrc_agricultural_hotspots/update_agricultural_hotspots.R
+++ b/src/indicators/jrc_agricultural_hotspots/update_agricultural_hotspots.R
@@ -10,7 +10,7 @@ box::use(./utils/plot_agricultural_hotspots)
 box::use(../../alerts/generate_signals[generate_signals])
 box::use(../../utils/hs_logger)
 
-test <- as.logical(Sys.getenv("HS_TEST", unset = FALSE))
+test <- as.logical(Sys.getenv("HS_TEST", unset = TRUE))
 test_filter <- if (test) c("AFG", "SSD") else NULL
 indicator_id <- "jrc_agricultural_hotspots"
 

--- a/src/utils/ai_summarizer.R
+++ b/src/utils/ai_summarizer.R
@@ -1,7 +1,7 @@
 box::use(purrr)
 box::use(openai)
 box::use(stringr)
-box::use(logger[log_info, log_debug])
+box::use(logger[log_debug])
 
 box::use(../utils/gmas_test_run[gmas_test_run])
 box::use(../utils/get_env[get_env])

--- a/src/utils/get_env.R
+++ b/src/utils/get_env.R
@@ -14,10 +14,8 @@ get_env <- function(env_var_name, output = TRUE) {
   if (!nzchar(val)) {
     error_message <- sprintf("Environment variable '%s' is empty or not set.", env_var_name)
     log_error(error_message)
-    stop()
-  } else {
-    if (output) {
-      return(val)
-    }
+    stop(call. = FALSE)
+  } else if (output) {
+    val
   }
 }


### PR DESCRIPTION
Fixes to some issues found in the code.

1. `log_info()` in `generate_signals()` was the final statement, so the logging was the return value, instead of the dataset itself. I didn't think I could find anywhere else where that error existed.
2. I think `test` being unset should always be `TRUE`. Runs should only be done intentionally. Are we sure we don't want `test` to be internal to the function, so we just use the env variable and remove the duplicated calls in each `update_{indicator}.R` script?
3. I have changed it so we only throw errors on warnings when not interactive. This should allow for a lot more flexibility when interactively developing. What do you think?
4. Some other small changes I notice when doing some runs.