### PR TITLE
Use new logo without the pattern

### DIFF
--- a/src/email/components/hdx_signals_template.html
+++ b/src/email/components/hdx_signals_template.html
@@ -580,7 +580,7 @@
                         <tbody><tr>
                             <td class="mcnImageContent" valign="top" style="padding-right: 0px; padding-left: 0px; padding-top: 0; padding-bottom: 0;">
                                     <a href="https://centre.humdata.org/" title="" class="" target="_blank">
-                                        <img align="left" alt="HDX Signals: Extracting signals from the noise" src="https://mcusercontent.com/ea3f905d50ea939780139789d/images/fdb5015f-4ef9-c1e2-f99e-058189c958b4.png" width="402" style="max-width:721px; padding-bottom: 0; display: inline !important; vertical-align: bottom;" class="mcnImage">
+                                        <img align="left" alt="HDX Signals: Extracting signals from the noise" src="https://mcusercontent.com/ea3f905d50ea939780139789d/images/bd99cc4e-1094-738f-12e3-338648b6dadb.png" width="402" style="max-width:721px; padding-bottom: 0; padding-left: 18px; display: inline !important; vertical-align: bottom;" class="mcnImage">
                                     </a>
                             </td>
                         </tr>


### PR DESCRIPTION
Simple shift to use new logo stored on Mailchimp.