### PR TITLE
Setting plot and panel background to white

### DIFF
--- a/src/images/plots/theme_signals.R
+++ b/src/images/plots/theme_signals.R
@@ -21,6 +21,8 @@ theme_signals <- function() {
       axis.text = gg$element_text(size = 11),
       plot.caption = gg$element_text(size = 11, hjust = 1),
       legend.text = gg$element_text(size = 9),
-      legend.title = gg$element_text(size = 11)
+      legend.title = gg$element_text(size = 11),
+      panel.background = gg$element_rect(fill = "white"),
+      plot.background = gg$element_rect(fill = "white")
     )
 }

--- a/src/images/plots/theme_signals.R
+++ b/src/images/plots/theme_signals.R
@@ -22,7 +22,7 @@ theme_signals <- function() {
       plot.caption = gg$element_text(size = 11, hjust = 1),
       legend.text = gg$element_text(size = 9),
       legend.title = gg$element_text(size = 11),
-      panel.background = gg$element_rect(fill = "white"),
-      plot.background = gg$element_rect(fill = "white")
+      panel.background = gg$element_rect(fill = "white", linewidth = 0),
+      plot.background = gg$element_rect(fill = "white", linewidth = 0)
     )
 }


### PR DESCRIPTION
Set plot and panel background to white. Transparent background ran into issues with dark mode. Not sure if I need to set both, but I believe `plot.background` is limited to plot extents, but `ggsave(..., bg = NULL)` is the default argument and when `bg` is `NULL`, it saves with the value specified as `plot.background`. So figured safer to set both.