### PR TITLE
fct_expand + fct_relevel legend order to ensure consistency

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -438,6 +438,22 @@
       "Repository": "CRAN",
       "Hash": "8106d78941f34855c440ddb946b8f7a5"
     },
+    "forcats": {
+      "Package": "forcats",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "rlang",
+        "tibble"
+      ],
+      "Hash": "1a0a9a3d5083d0d573c4214576f1e690"
+    },
     "generics": {
       "Package": "generics",
       "Version": "0.1.3",

--- a/src/indicators/jrc_agricultural_hotspots/utils/plot_agricultural_hotspots.R
+++ b/src/indicators/jrc_agricultural_hotspots/utils/plot_agricultural_hotspots.R
@@ -69,8 +69,8 @@ hotspots_ts <- function(df_wrangled, df_raw, title, date) {
     dplyr$mutate(
       year = lubridate$year(date),
       month = lubridate$month(date, label = TRUE),
-      hs_name = forcats$fct_expand(hs_name,"Major hotspot" ,"Hotspot","No hotspot"),
-      hs_name = forcats$fct_relevel(hs_name, "Major hotspot" ,"Hotspot","No hotspot")
+      hs_name = forcats$fct_expand(hs_name, "Major hotspot", "Hotspot", "No hotspot"),
+      hs_name = forcats$fct_relevel(hs_name, "Major hotspot", "Hotspot", "No hotspot")
     ) |>
     dplyr$filter(
       max(year, -Inf) - year < 5

--- a/src/indicators/jrc_agricultural_hotspots/utils/plot_agricultural_hotspots.R
+++ b/src/indicators/jrc_agricultural_hotspots/utils/plot_agricultural_hotspots.R
@@ -1,5 +1,6 @@
 box::use(dplyr)
 box::use(scales)
+box::use(forcats)
 box::use(gg = ggplot2)
 box::use(gghdx)
 box::use(lubridate)
@@ -67,7 +68,9 @@ hotspots_ts <- function(df_wrangled, df_raw, title, date) {
   df_plot <- df_wrangled |>
     dplyr$mutate(
       year = lubridate$year(date),
-      month = lubridate$month(date, label = TRUE)
+      month = lubridate$month(date, label = TRUE),
+      hs_name = forcats$fct_expand(hs_name,"Major hotspot" ,"Hotspot","No hotspot"),
+      hs_name = forcats$fct_relevel(hs_name, "Major hotspot" ,"Hotspot","No hotspot")
     ) |>
     dplyr$filter(
       max(year, -Inf) - year < 5
@@ -102,9 +105,6 @@ hotspots_ts <- function(df_wrangled, df_raw, title, date) {
       )
     ) +
     gg$labs(
-      x = "",
-      y = "",
-      fill = "",
       title = title,
       caption = caption
     ) +
@@ -113,6 +113,8 @@ hotspots_ts <- function(df_wrangled, df_raw, title, date) {
       fill = gg$guide_legend(byrow = TRUE)
     ) +
     gg$theme(
+      legend.title = gg$element_blank(),
+      axis.title   = gg$element_blank(),
       panel.grid = gg$element_blank(),
       legend.position = "left",
       legend.direction = "vertical",


### PR DESCRIPTION
Added in `fct_expand` + `fct_relevel` to make sure JRC legend always has all 3 factor levels in the same order for plot legend.

closes #130