### PR TITLE
Fix string when no alerts are detected

### DIFF
--- a/src/signals/check_signals_updates.R
+++ b/src/signals/check_signals_updates.R
@@ -187,7 +187,7 @@ indicators <- ".github/workflows" |>
 
 full_status <- ""
 n_signals <- 0
-signals <- ""
+signals <- " "
 test <- Sys.getenv("HS_TEST", unset = TRUE)
 
 for (ind in indicators) {


### PR DESCRIPTION
Today was the first run with no signals detected, which [caused an error](https://github.com/OCHA-DAP/hdx-signals/actions/runs/9497646763/job/26174699811) with the Slack API due to an empty string. 