### PR TITLE
remove interaction data from interest data before appending

### DIFF
--- a/src/email/create_user_analytics_dataset.R
+++ b/src/email/create_user_analytics_dataset.R
@@ -137,6 +137,13 @@ df_members <- purrr$map(
     name != "" # HDX Signals email
   )
 
+df_member_interactions_new <- df_members |>
+  dplyr$group_by(id) |>
+  dplyr$distinct(open_rate, click_rate, email_count) |>
+  dplyr$ungroup() |>
+  dplyr$mutate(
+    extraction_date = lubridate$as_date(Sys.Date())
+  )
 
 df_members_new <- df_members |>
   dplyr$mutate(
@@ -145,17 +152,8 @@ df_members_new <- df_members |>
     extraction_date = lubridate$as_date(Sys.Date())
   ) |>
   dplyr$select(
-    -dplyr$all_of(c("name", "email"))
+    -dplyr$all_of(c("name", "email","open_rate", "click_rate", "email_count"))
   )
-
-df_member_interactions_new <- df_members_new |>
-  dplyr$group_by(id) |>
-  dplyr$distinct(open_rate, click_rate, email_count) |>
-  dplyr$ungroup() |>
-  dplyr$mutate(
-    extraction_date = lubridate$as_date(Sys.Date())
-  )
-
 
 df_contact <- df_members |>
   dplyr$distinct(id, name, email)

--- a/src/email/create_user_analytics_dataset.R
+++ b/src/email/create_user_analytics_dataset.R
@@ -152,7 +152,7 @@ df_members_new <- df_members |>
     extraction_date = lubridate$as_date(Sys.Date())
   ) |>
   dplyr$select(
-    -dplyr$all_of(c("name", "email","open_rate", "click_rate", "email_count"))
+    -dplyr$all_of(c("name", "email", "open_rate", "click_rate", "email_count"))
   )
 
 df_contact <- df_members |>


### PR DESCRIPTION
added step to remove user interaction data from user interests data.frame prior to checking blob and appending data. I deleted user-interests on blob to start fresh csv with this [run](https://github.com/OCHA-DAP/hdx-signals/actions/runs/12054973407)....


Do we forsee an issue that now we have one extraction date for user interests...but multiple for others? 

i think we could ignore the CHANGES failed test for this