### PR TITLE
fix(dispatch_signals): 🐛 handle archival of already-sent campaigns

### DIFF
--- a/.github/workflows/triage_signals.yaml
+++ b/.github/workflows/triage_signals.yaml
@@ -84,6 +84,7 @@ jobs:
       USER_COMMAND: ${{ inputs.USER_COMMAND || 'DO_NOTHING' }}
       USER_COMMAND_CONFIRMATION: ${{ inputs.USER_COMMAND_CONFIRMATION || 'I CONFIRM' }}
       HS_ADMIN_NAME: ${{ secrets.HS_ADMIN_NAME }}
+      HS_HDX_BEARER: ${{ secrets.HS_HDX_BEARER }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/src/run/run_triage_signals.R
+++ b/src/run/run_triage_signals.R
@@ -6,5 +6,5 @@ box::use(
 triage_signals$triage_signals(
   indicator_id = get_env$get_env("INDICATOR_ID"),
   n_campaigns = 0,
-  test = get_env$get_env("TEST")
+  test = as.logical(get_env$get_env("TEST"))
 )

--- a/src/signals/check_signals_updates.R
+++ b/src/signals/check_signals_updates.R
@@ -176,7 +176,7 @@ slack_build_workflow_status <- function(indicator_id) {
       date == Sys.Date()
     )
   }
-  if(nrow(df_sel)==2){
+  if(nrow(df_sel)>1){
     df_sel_filt <- df_sel |>
       dplyr$filter(workflow_runs.conclusion=="success")
     status <- df_sel_filt$workflow_runs.conclusion
@@ -188,8 +188,7 @@ slack_build_workflow_status <- function(indicator_id) {
     } else if (status == "success") {
       paste0(":large_green_circle: ", indicator_id, ": Successful update \n")
     }
-    # If no scheduled runs happened off of main today
-
+    # If no scheduled runs happened off of main toda
   }
 
   if (nrow(df_sel) == 1) {
@@ -204,11 +203,12 @@ slack_build_workflow_status <- function(indicator_id) {
     }
     # If no scheduled runs happened off of main today
   }
-  else if (nrow(df_sel) == 0) {
+   if (nrow(df_sel) == 0) {
     paste0(":heavy_minus_sign: ", indicator_id, ": No scheduled update \n")
-  } else {
-    paste0(":red_circle: ", indicator_id, ": More than one scheduled run today \n")
   }
+  # else {
+  #   paste0(":red_circle: ", indicator_id, ": More than one scheduled run today \n")
+  # }
 }
 
 # Get the indicator ids of all workflows

--- a/src/signals/check_signals_updates.R
+++ b/src/signals/check_signals_updates.R
@@ -160,12 +160,22 @@ slack_build_workflow_status <- function(indicator_id) {
   }
   # Get today's scheduled runs from the main branch
   df_runs$date <- as.Date(df_runs$workflow_runs.created_at)
+  if(indicator_id=="idmc_displacement_conflict"){
   df_sel <- dplyr$filter(
     df_runs,
     workflow_runs.event %in% c( "schedule","workflow_dispatch"),
     workflow_runs.head_branch == "main",
     date == Sys.Date()
   )
+  }
+  else{
+    df_sel <- dplyr$filter(
+      df_runs,
+      workflow_runs.event %in% c( "schedule"),
+      workflow_runs.head_branch == "main",
+      date == Sys.Date()
+    )
+  }
   if(nrow(df_sel)==2){
     df_sel_filt <- df_sel |>
       dplyr$filter(workflow_runs.conclusion=="success")
@@ -179,11 +189,7 @@ slack_build_workflow_status <- function(indicator_id) {
       paste0(":large_green_circle: ", indicator_id, ": Successful update \n")
     }
     # If no scheduled runs happened off of main today
-  } else if (nrow(df_sel) == 0) {
-    paste0(":heavy_minus_sign: ", indicator_id, ": No scheduled update \n")
-  } else {
-    paste0(":red_circle: ", indicator_id, ": More than one scheduled run today \n")
-  }
+
   }
 
   if (nrow(df_sel) == 1) {
@@ -197,7 +203,8 @@ slack_build_workflow_status <- function(indicator_id) {
       paste0(":large_green_circle: ", indicator_id, ": Successful update \n")
     }
     # If no scheduled runs happened off of main today
-  } else if (nrow(df_sel) == 0) {
+  }
+  else if (nrow(df_sel) == 0) {
     paste0(":heavy_minus_sign: ", indicator_id, ": No scheduled update \n")
   } else {
     paste0(":red_circle: ", indicator_id, ": More than one scheduled run today \n")
@@ -218,7 +225,7 @@ n_signals <- 0
 # Needs to have at least 1 character for the Slack API
 signals <- " "
 dry_run <- hs_dry_run$hs_dry_run()
-
+dry_run <- FALSE
 for (ind in indicators) {
   logger$log_info(paste0("Checking GitHub Actions status for ", ind, "..."))
   workflow_status <- slack_build_workflow_status(ind)

--- a/src/signals/triage_signals.R
+++ b/src/signals/triage_signals.R
@@ -196,9 +196,7 @@ approve_signals <- function(df, fn_signals, test, indicator_id) {
 #' @param test Whether or not the signals were in the test folder.
 #' @param user_command command provided by the user
 dispatch_signals <- function(df, fn_signals, test=NULL, user_command) {
-  if(is.null(test)){
-    test <- hs_triage_test$hs_triage_test()
-  }
+
   if (user_command %in% c("APPROVE", "ARCHIVE")) {
     if (user_command == "ARCHIVE") {
       # delete the email template and campaigns, but not the content

--- a/src/signals/triage_signals.R
+++ b/src/signals/triage_signals.R
@@ -11,7 +11,8 @@ box::use(
   src/email/mailchimp/campaigns,
   cs = src/utils/cloud_storage,
   src/utils/get_env,
-  src/utils/push_hdx
+  src/utils/push_hdx,
+  src/utils/hs_triage_test
 )
 
 #' Triage signals generated automatically
@@ -194,7 +195,10 @@ approve_signals <- function(df, fn_signals, test, indicator_id) {
 #' @param fn_signals File name to the signals data
 #' @param test Whether or not the signals were in the test folder.
 #' @param user_command command provided by the user
-dispatch_signals <- function(df, fn_signals, test, user_command) {
+dispatch_signals <- function(df, fn_signals, test=NULL, user_command) {
+  if(is.null(test)){
+    test <- hs_triage_test$hs_triage_test()
+  }
   if (user_command %in% c("APPROVE", "ARCHIVE")) {
     if (user_command == "ARCHIVE") {
       # delete the email template and campaigns, but not the content
@@ -210,7 +214,7 @@ dispatch_signals <- function(df, fn_signals, test, user_command) {
           stop(e) # re-throw if it's a different error
         }
       })
-      
+
       # ensure ALL campaign ID columns are empty (including archive campaigns)
       df <- dplyr$mutate(
         df,

--- a/src/utils/hs_triage_test.R
+++ b/src/utils/hs_triage_test.R
@@ -1,0 +1,17 @@
+#' Checks if triage operations should run in test mode
+#'
+#' `hs_triage_test()` looks for the environment variable `TEST`. This is
+#' used in `triage_signals()` to determine whether to save data to production
+#' files or run in test mode.
+#'
+#' By default, if `TEST` is not set, then it defaults to `TRUE`. This
+#' means in interactive development sessions signals will not be moved to
+#' the core `output/signals.parquet` file. It is used in:
+#' * `dispatch_signals()` to prevent saving triaged signals to production files
+#' * Test mode allows campaign operations (send/delete) but prevents file modifications
+#'
+#' @export
+hs_triage_test <- function() {
+  test_val <- Sys.getenv("TEST", unset = "TRUE")
+  as.logical(test_val)
+}


### PR DESCRIPTION
We might not want to merge this, but could try running the GHA on this branch with this work around to clean up the signals files which are causing downstream issues.

**Error handling and campaign archival:**
- Wrapped the campaign deletion logic in a `tryCatch` block to gracefully handle cases where campaigns have already been sent and cannot be deleted from Mailchimp, logging a message instead of failing the process. Other errors are still raised.
- Ensured that all campaign ID columns, including those for archive campaigns, are emptied after attempting deletion, regardless of whether deletion was successful.

**Signal dispatch logic:**
- Modified the logic so that signals are only sent when the user command is `APPROVE`, not when archiving, preventing unnecessary signal dispatch during archival.