### PR TITLE
fix: 🐛 cast `TEST` environment variable to logical

### DIFF
--- a/src/run/run_triage_signals.R
+++ b/src/run/run_triage_signals.R
@@ -6,5 +6,5 @@ box::use(
 triage_signals$triage_signals(
   indicator_id = get_env$get_env("INDICATOR_ID"),
   n_campaigns = 0,
-  test = get_env$get_env("TEST")
+  test = as.logical(get_env$get_env("TEST"))
 )


### PR DESCRIPTION

This pull request makes a minor update to the way the `test` parameter is handled in the `triage_signals$triage_signals` function call, ensuring that its value is explicitly converted to a logical type.