### PR TITLE
add hdx bearer token to triage yaml

### DIFF
--- a/.github/workflows/triage_signals.yaml
+++ b/.github/workflows/triage_signals.yaml
@@ -84,6 +84,7 @@ jobs:
       USER_COMMAND: ${{ inputs.USER_COMMAND || 'DO_NOTHING' }}
       USER_COMMAND_CONFIRMATION: ${{ inputs.USER_COMMAND_CONFIRMATION || 'I CONFIRM' }}
       HS_ADMIN_NAME: ${{ secrets.HS_ADMIN_NAME }}
+      HS_HDX_BEARER: ${{ secrets.HS_HDX_BEARER }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## PR Description

Here we just add the HDX BEARER token which is needed for triaging to the yaml (see autogen summary below for more explanation).

### Copilot auto description

This pull request makes a minor update to the GitHub Actions workflow by adding a new secret environment variable to the job configuration.

- Workflow configuration:
  * Added the `HS_HDX_BEARER` secret as an environment variable in the `.github/workflows/triage_signals.yaml` workflow file.

## Triaging fix/sequencing overview

Just providing a bit of an explanation on the last triaging for future understanding:

The fixes made here were done in this manner because we didn't have access to the PROD WRITE key so all troubleshooting and "manual" cleaning of files were done via GHA.

1. Aug 5 signals were triaged approved locally. The signals were sent but because local analyst did not have PROD write key the parquet files didn't get cleaned up. This cause subsequent failures.
2. Aug 6 failures
3. Aug 7: to fix the system and address failures I revised the way GHA triage signals archives https://github.com/OCHA-DAP/hdx-signals/pull/306. -- this requires more explanation that i'll put into that PR eventually.
4. Aug 7: the fix worked and new signals identified
5. Aug 8: I made minor adjustments to triage GHA so that it would we could run it to APPROVE and send the signals [merged PR](https://github.com/OCHA-DAP/hdx-signals/pull/307). 
6. Aug 8: I then triaged via GHA to APPROVE and emails sent. However I panicked when I saw an error (the error which is fixed in this PR). Upon panicking i cancelled the run, but the emails had already been sent. This was good, but the error cause the parquet files not to get completely cleaned up once again.
7. Therefore, what I will do now is run the ARCHIVE triage on the archive-workaround branch to clean the parquet files. Once that is done and this commit is merged we should be back in action.

There will be a minor future job of cleaning up the parquet logs to indicate that the signals sent today as well as Aug 5 were indeed sent rather than archived, but this should be straight forward and wont effect how the system operates.

