### PR TITLE
Feat: add global choropleth map for sea5_anomaly indicator

### DIFF
--- a/src/indicators/sea5_anomaly/utils/map_sea5_anomaly.R
+++ b/src/indicators/sea5_anomaly/utils/map_sea5_anomaly.R
@@ -1,8 +1,7 @@
 box::use(
   dplyr,
   gg = ggplot2,
-  rnaturalearth,
-  scales
+  rnaturalearth
 )
 
 box::use(
@@ -11,14 +10,54 @@ box::use(
   src/images/maps/map_theme
 )
 
+# Thresholds matching ds-seas5-skill defaults.
+# vsev/sev percentile bounds are derived from return periods.
+SEA5_R_MOD   <- 0.3
+SEA5_R_HIGH  <- 0.5
+SEA5_VSEV_M  <- 100 / 10  # 10th / 90th percentile (10-year RP)
+SEA5_SEV_M   <- 100 / 3   # 33rd / 67th percentile (3-year RP)
+
+# Ordered factor levels — determines legend order.
+CATEGORY_LEVELS <- c(
+  "strongly_below", "below_normal", "roughly_normal",
+  "above_normal", "strongly_above",
+  "roughly_normal_mod", "low_skill", "off_season", "not_monitored"
+)
+
+CATEGORY_COLORS <- c(
+  "strongly_below"     = "#7B3A1A",
+  "below_normal"       = "#C8844A",
+  "roughly_normal"     = "#FFFFFF",
+  "above_normal"       = "#71B3E5",
+  "strongly_above"     = "#0D40B0",
+  "roughly_normal_mod" = "#E0E0E0",
+  "low_skill"          = "#C8C8C8",
+  "off_season"         = "#D0D0D0",
+  "not_monitored"      = "#F5F5F5"
+)
+
+CATEGORY_LABELS <- c(
+  "strongly_below"     = "Strongly below normal",
+  "below_normal"       = "Below normal",
+  "roughly_normal"     = "Roughly normal",
+  "above_normal"       = "Above normal",
+  "strongly_above"     = "Strongly above normal",
+  "roughly_normal_mod" = "Roughly normal (mod skill)",
+  "low_skill"          = "Low skill",
+  "off_season"         = "Outside rainy season",
+  "not_monitored"      = "Not monitored"
+)
+
 #' Map SEA5 anomaly
 #'
-#' Creates a global choropleth map for SEA5 anomaly, showing p_5rp values
+#' Creates a global choropleth map for SEA5 anomaly, showing forecast categories
 #' for the next valid trimester from the forecast date across all countries.
+#' Categories and colours match the ds-seas5-skill reference map.
 #'
 #' @param df_alerts Data frame of alerts
 #' @param df_wrangled Wrangled data frame
-#' @param df_raw Raw data
+#' @param df_raw Raw data frame. Must contain columns `iso3`, `date`,
+#'     `forecast_percentile`, `pearson_r`, and `is_rainy`.
 #' @param preview Whether or not to preview the plots
 #'
 #' @export
@@ -37,13 +76,13 @@ map <- function(df_alerts, df_wrangled, df_raw, preview = FALSE) {
 
 #' Map SEA5 anomaly data at global level
 #'
-#' Produces a global choropleth map showing all countries colored by their
-#' p_5rp values (probability of exceeding the 5-year return period) for
-#' the next valid trimester from the forecast date.
+#' Produces a global choropleth map with countries coloured by their forecast
+#' category for the next valid trimester. Category logic is a faithful port of
+#' the ds-seas5-skill `classify()` function (docs/app.js).
 #'
 #' @param df_wrangled Wrangled data frame for plotting (single alerted country).
 #' @param df_raw Raw data frame (all countries).
-#' @param title Plot title.
+#' @param title Plot title (unused; title is fixed to reflect the trimester).
 #' @param date Date of the alert.
 #'
 #' @returns Global choropleth ggplot object
@@ -55,20 +94,41 @@ sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
   month_initials <- c("J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D")
   trimester_label <- paste(month_initials[trimester_month_nums], collapse = "")
 
-  # filter df_raw to the most recent forecast date up to the alert date
+  # filter to the most recent forecast date up to the alert date, then classify
   alert_date <- date
   df_map_data <- df_raw |>
     dplyr$filter(date <= alert_date) |>
-    dplyr$filter(date == max(date))
+    dplyr$filter(date == max(date)) |>
+    dplyr$transmute(
+      iso3,
+      category = dplyr$case_when(
+        is.na(pearson_r) | is.na(forecast_percentile) ~ "off_season",
+        !is_rainy                                      ~ "off_season",
+        pearson_r < SEA5_R_MOD                         ~ "low_skill",
+        # strongly below / above normal (outside 10th / 90th pct)
+        forecast_percentile <= SEA5_VSEV_M &
+          forecast_percentile < 50                     ~ "strongly_below",
+        forecast_percentile >= 100 - SEA5_VSEV_M &
+          forecast_percentile >= 50                    ~ "strongly_above",
+        # below / above normal (10th–33rd / 67th–90th pct)
+        forecast_percentile > SEA5_VSEV_M &
+          forecast_percentile <= SEA5_SEV_M            ~ "below_normal",
+        forecast_percentile >= 100 - SEA5_SEV_M &
+          forecast_percentile < 100 - SEA5_VSEV_M      ~ "above_normal",
+        # roughly normal: split by skill level
+        pearson_r >= SEA5_R_HIGH                       ~ "roughly_normal",
+        .default                                        = "roughly_normal_mod"
+      )
+    )
 
-  # get world country boundaries
   sf_world <- rnaturalearth$ne_countries(scale = "medium", returnclass = "sf")
 
-  # join world boundaries with p_5rp values by ISO3 code
+  # join and assign "not_monitored" to any country absent from df_raw
   sf_data <- sf_world |>
-    dplyr$left_join(
-      dplyr$select(df_map_data, iso3, p_5rp),
-      by = c("iso_a3" = "iso3")
+    dplyr$left_join(df_map_data, by = c("iso_a3" = "iso3")) |>
+    dplyr$mutate(
+      category = dplyr$if_else(is.na(category), "not_monitored", category),
+      category = factor(category, levels = CATEGORY_LEVELS)
     )
 
   map_caption <- caption$caption(
@@ -80,17 +140,15 @@ sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
   gg$ggplot() +
     gg$geom_sf(
       data = sf_data,
-      mapping = gg$aes(fill = p_5rp),
-      color = "white",
+      mapping = gg$aes(fill = category),
+      color = "#5A5A5A",
       linewidth = 0.1
     ) +
-    gg$scale_fill_distiller(
-      palette = "YlOrRd",
-      direction = 1,
-      limits = c(0, 1),
-      na.value = "grey90",
-      labels = scales$label_percent(),
-      name = "Probability"
+    gg$scale_fill_manual(
+      values = CATEGORY_COLORS,
+      labels = CATEGORY_LABELS,
+      drop = FALSE,
+      name = NULL
     ) +
     gg$coord_sf(
       clip = "off",
@@ -99,7 +157,7 @@ sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
     gg$labs(
       x = "",
       y = "",
-      title = "Probability of exceeding 5-year return period",
+      title = "SEA5 seasonal forecast",
       subtitle = trimester_label,
       caption = map_caption
     ) +

--- a/src/indicators/sea5_anomaly/utils/map_sea5_anomaly.R
+++ b/src/indicators/sea5_anomaly/utils/map_sea5_anomaly.R
@@ -1,17 +1,20 @@
 box::use(
-  gg = ggplot2
+  dplyr,
+  gg = ggplot2,
+  rnaturalearth,
+  scales
 )
 
 box::use(
   src/images/create_images,
   src/images/plots/caption,
-  src/images/maps/sf_adm0,
   src/images/maps/map_theme
 )
 
 #' Map SEA5 anomaly
 #'
-#' Creates an adm0-level map for SEA5 anomaly alerts.
+#' Creates a global choropleth map for SEA5 anomaly, showing p_5rp values
+#' for the next valid trimester from the forecast date across all countries.
 #'
 #' @param df_alerts Data frame of alerts
 #' @param df_wrangled Wrangled data frame
@@ -26,36 +29,68 @@ map <- function(df_alerts, df_wrangled, df_raw, preview = FALSE) {
     df_raw = df_raw,
     image_fn = sea5_anomaly_map,
     image_use = "map",
-    width = 6,
-    height = 4,
-    settings = "map"
+    width = 10,
+    height = 5,
+    settings = "plot"
   )
 }
 
-#' Map SEA5 anomaly data at adm0 level
+#' Map SEA5 anomaly data at global level
 #'
-#' Produces an adm0-level map showing the country boundary for the alert.
+#' Produces a global choropleth map showing all countries colored by their
+#' p_5rp values (probability of exceeding the 5-year return period) for
+#' the next valid trimester from the forecast date.
 #'
-#' @param df_wrangled Wrangled data frame for plotting.
-#' @param df_raw Raw data frame.
+#' @param df_wrangled Wrangled data frame for plotting (single alerted country).
+#' @param df_raw Raw data frame (all countries).
 #' @param title Plot title.
 #' @param date Date of the alert.
 #'
-#' @returns adm0 map for the alert location
+#' @returns Global choropleth ggplot object
 sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
-  iso3 <- unique(df_wrangled$iso3)
+  # compute next valid trimester label (starts 1 month after forecast date)
+  forecast_month <- as.integer(format(date, "%m"))
+  start_month <- (forecast_month %% 12L) + 1L
+  trimester_month_nums <- (start_month - 1L + c(0L, 1L, 2L)) %% 12L + 1L
+  month_initials <- c("J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D")
+  trimester_label <- paste(month_initials[trimester_month_nums], collapse = "")
+
+  # filter df_raw to the most recent forecast date up to the alert date
+  alert_date <- date
+  df_map_data <- df_raw |>
+    dplyr$filter(date <= alert_date) |>
+    dplyr$filter(date == max(date))
+
+  # get world country boundaries
+  sf_world <- rnaturalearth$ne_countries(scale = "medium", returnclass = "sf")
+
+  # join world boundaries with p_5rp values by ISO3 code
+  sf_data <- sf_world |>
+    dplyr$left_join(
+      dplyr$select(df_map_data, iso3, p_5rp),
+      by = c("iso_a3" = "iso3")
+    )
 
   map_caption <- caption$caption(
     indicator_id = "sea5_anomaly",
-    iso3 = iso3,
-    map = TRUE
+    iso3 = unique(df_wrangled$iso3),
+    map = FALSE
   )
-
-  sf_list <- sf_adm0$sf_adm0(iso3 = iso3)
 
   gg$ggplot() +
     gg$geom_sf(
-      data = sf_list$sf_adm0
+      data = sf_data,
+      mapping = gg$aes(fill = p_5rp),
+      color = "white",
+      linewidth = 0.1
+    ) +
+    gg$scale_fill_distiller(
+      palette = "YlOrRd",
+      direction = 1,
+      limits = c(0, 1),
+      na.value = "grey90",
+      labels = scales$label_percent(),
+      name = "Probability"
     ) +
     gg$coord_sf(
       clip = "off",
@@ -64,12 +99,16 @@ sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
     gg$labs(
       x = "",
       y = "",
-      title = title,
+      title = paste0(
+        "Probability of exceeding 5-year return period (",
+        trimester_label,
+        ")"
+      ),
       caption = map_caption
     ) +
     map_theme$map_theme(
-      iso3 = iso3,
-      use_map_settings = TRUE,
-      margin_location = "subtitle"
+      iso3 = unique(df_wrangled$iso3),
+      use_map_settings = FALSE,
+      margin_location = "title"
     )
 }

--- a/src/indicators/sea5_anomaly/utils/map_sea5_anomaly.R
+++ b/src/indicators/sea5_anomaly/utils/map_sea5_anomaly.R
@@ -1,6 +1,7 @@
 box::use(
   dplyr,
   gg = ggplot2,
+  ggpattern,
   rnaturalearth
 )
 
@@ -17,35 +18,51 @@ SEA5_R_HIGH  <- 0.5
 SEA5_VSEV_M  <- 100 / 10  # 10th / 90th percentile (10-year RP)
 SEA5_SEV_M   <- 100 / 3   # 33rd / 67th percentile (3-year RP)
 
-# Ordered factor levels — determines legend order.
-CATEGORY_LEVELS <- c(
+# Ordered factor levels — determines legend order (drier to wetter, then extras).
+ANOMALY_LEVELS <- c(
   "strongly_below", "below_normal", "roughly_normal",
   "above_normal", "strongly_above",
-  "roughly_normal_mod", "low_skill", "off_season", "not_monitored"
+  "off_season", "not_monitored"
 )
 
-CATEGORY_COLORS <- c(
-  "strongly_below"     = "#7B3A1A",
-  "below_normal"       = "#C8844A",
-  "roughly_normal"     = "#FFFFFF",
-  "above_normal"       = "#71B3E5",
-  "strongly_above"     = "#0D40B0",
-  "roughly_normal_mod" = "#E0E0E0",
-  "low_skill"          = "#C8C8C8",
-  "off_season"         = "#D0D0D0",
-  "not_monitored"      = "#F5F5F5"
+# Brand color tokens, one contiguous strip from drier to wetter.
+ANOMALY_COLORS <- c(
+  "strongly_below" = "#7f5619",
+  "below_normal"   = "#dda555",
+  "roughly_normal" = "#e2e8e8",
+  "above_normal"   = "#74a1e8",
+  "strongly_above" = "#134ead",
+  "off_season"     = "#b1c1c2",
+  "not_monitored"  = "#f5f7f7"
 )
 
-CATEGORY_LABELS <- c(
-  "strongly_below"     = "Strongly below normal",
-  "below_normal"       = "Below normal",
-  "roughly_normal"     = "Roughly normal",
-  "above_normal"       = "Above normal",
-  "strongly_above"     = "Strongly above normal",
-  "roughly_normal_mod" = "Roughly normal (mod skill)",
-  "low_skill"          = "Low skill",
-  "off_season"         = "Outside rainy season",
-  "not_monitored"      = "Not monitored"
+ANOMALY_LABELS <- c(
+  "strongly_below" = "Strongly below normal",
+  "below_normal"   = "Below normal",
+  "roughly_normal" = "Roughly normal",
+  "above_normal"   = "Above normal",
+  "strongly_above" = "Strongly above normal",
+  "off_season"     = "Outside rainy season",
+  "not_monitored"  = "Not monitored"
+)
+
+# Skill strip, shown as a solid/hatched pattern overlaid on the anomaly color.
+# "not_applicable" covers off-season / unmonitored countries — mapped to a
+# solid pattern but excluded from the legend via `breaks` (below).
+SKILL_LEVELS <- c("high_skill", "moderate_skill", "low_skill", "not_applicable")
+SKILL_BREAKS <- c("high_skill", "moderate_skill", "low_skill")
+
+SKILL_PATTERNS <- c(
+  "high_skill"     = "none",
+  "moderate_skill" = "stripe",
+  "low_skill"      = "crosshatch",
+  "not_applicable" = "none"
+)
+
+SKILL_LABELS <- c(
+  "high_skill"     = "High skill",
+  "moderate_skill" = "Moderate skill",
+  "low_skill"      = "Low skill"
 )
 
 #' Map SEA5 anomaly
@@ -77,8 +94,9 @@ map <- function(df_alerts, df_wrangled, df_raw, preview = FALSE) {
 #' Map SEA5 anomaly data at global level
 #'
 #' Produces a global choropleth map with countries coloured by their forecast
-#' category for the next valid trimester. Category logic is a faithful port of
-#' the ds-seas5-skill `classify()` function (docs/app.js).
+#' anomaly category for the next valid trimester (one contiguous strip from
+#' drier to wetter), with forecast skill shown as a solid/hatched pattern
+#' overlaid on top of the anomaly colour.
 #'
 #' @param df_wrangled Wrangled data frame for plotting (single alerted country).
 #' @param df_raw Raw data frame (all countries).
@@ -102,22 +120,18 @@ sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
     dplyr$transmute(
       iso3,
       category = dplyr$case_when(
-        is.na(pearson_r) | is.na(forecast_percentile) ~ "off_season",
-        !is_rainy                                      ~ "off_season",
-        pearson_r < SEA5_R_MOD                         ~ "low_skill",
-        # strongly below / above normal (outside 10th / 90th pct)
-        forecast_percentile <= SEA5_VSEV_M &
-          forecast_percentile < 50                     ~ "strongly_below",
-        forecast_percentile >= 100 - SEA5_VSEV_M &
-          forecast_percentile >= 50                    ~ "strongly_above",
-        # below / above normal (10th–33rd / 67th–90th pct)
-        forecast_percentile > SEA5_VSEV_M &
-          forecast_percentile <= SEA5_SEV_M            ~ "below_normal",
-        forecast_percentile >= 100 - SEA5_SEV_M &
-          forecast_percentile < 100 - SEA5_VSEV_M      ~ "above_normal",
-        # roughly normal: split by skill level
-        pearson_r >= SEA5_R_HIGH                       ~ "roughly_normal",
-        .default                                        = "roughly_normal_mod"
+        is.na(forecast_percentile) | is.na(is_rainy) | !is_rainy ~ "off_season",
+        forecast_percentile <= SEA5_VSEV_M          ~ "strongly_below",
+        forecast_percentile <= SEA5_SEV_M           ~ "below_normal",
+        forecast_percentile < 100 - SEA5_SEV_M      ~ "roughly_normal",
+        forecast_percentile < 100 - SEA5_VSEV_M     ~ "above_normal",
+        .default                                     = "strongly_above"
+      ),
+      skill = dplyr$case_when(
+        category == "off_season" | is.na(pearson_r) ~ "not_applicable",
+        pearson_r >= SEA5_R_HIGH                    ~ "high_skill",
+        pearson_r >= SEA5_R_MOD                     ~ "moderate_skill",
+        .default                                    = "low_skill"
       )
     )
 
@@ -128,7 +142,9 @@ sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
     dplyr$left_join(df_map_data, by = c("iso_a3" = "iso3")) |>
     dplyr$mutate(
       category = dplyr$if_else(is.na(category), "not_monitored", category),
-      category = factor(category, levels = CATEGORY_LEVELS)
+      category = factor(category, levels = ANOMALY_LEVELS),
+      skill = dplyr$if_else(is.na(skill), "not_applicable", skill),
+      skill = factor(skill, levels = SKILL_LEVELS)
     )
 
   map_caption <- caption$caption(
@@ -138,17 +154,29 @@ sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
   )
 
   gg$ggplot() +
-    gg$geom_sf(
+    ggpattern$geom_sf_pattern(
       data = sf_data,
-      mapping = gg$aes(fill = category),
+      mapping = gg$aes(fill = category, pattern = skill),
       color = "#5A5A5A",
-      linewidth = 0.1
+      linewidth = 0.1,
+      pattern_fill = "#5A5A5A",
+      pattern_colour = NA,
+      pattern_density = 0.15,
+      pattern_spacing = 0.015,
+      pattern_size = 0.15
     ) +
     gg$scale_fill_manual(
-      values = CATEGORY_COLORS,
-      labels = CATEGORY_LABELS,
+      values = ANOMALY_COLORS,
+      labels = ANOMALY_LABELS,
       drop = FALSE,
       name = NULL
+    ) +
+    ggpattern$scale_pattern_manual(
+      values = SKILL_PATTERNS,
+      breaks = SKILL_BREAKS,
+      labels = SKILL_LABELS,
+      drop = FALSE,
+      name = "Forecast skill"
     ) +
     gg$coord_sf(
       clip = "off",
@@ -160,6 +188,10 @@ sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
       title = "SEA5 seasonal forecast",
       subtitle = trimester_label,
       caption = map_caption
+    ) +
+    gg$guides(
+      fill = gg$guide_legend(order = 1, override.aes = list(pattern = "none")),
+      pattern = gg$guide_legend(order = 2, override.aes = list(fill = "#e2e8e8"))
     ) +
     map_theme$map_theme(
       iso3 = unique(df_wrangled$iso3),

--- a/src/indicators/sea5_anomaly/utils/map_sea5_anomaly.R
+++ b/src/indicators/sea5_anomaly/utils/map_sea5_anomaly.R
@@ -99,16 +99,13 @@ sea5_anomaly_map <- function(df_wrangled, df_raw, title, date) {
     gg$labs(
       x = "",
       y = "",
-      title = paste0(
-        "Probability of exceeding 5-year return period (",
-        trimester_label,
-        ")"
-      ),
+      title = "Probability of exceeding 5-year return period",
+      subtitle = trimester_label,
       caption = map_caption
     ) +
     map_theme$map_theme(
       iso3 = unique(df_wrangled$iso3),
       use_map_settings = FALSE,
-      margin_location = "title"
+      margin_location = "subtitle"
     )
 }


### PR DESCRIPTION
## Summary

Closes #343

- Replaces the per-country adm0 boundary map with a global choropleth map showing `p_5rp` values for all countries
- The map displays the next valid trimester (e.g., July forecast → ASO), computed from the alert date
- Countries with no data are shown in grey; coloring uses a Yellow-Orange-Red scale from 0–100% probability
- Switched from `settings = "map"` (per-country dimensions) to `settings = "plot"` with fixed 10x5 inch global dimensions

## Test plan

- [ ] Trigger a dry run of the `monitor_sea5_anomaly` workflow and verify the map image shows a world map with countries colored by `p_5rp`
- [ ] Confirm trimester label in the map title is correct for the forecast month (e.g., July forecast → `ASO`)
- [ ] Confirm countries with no data display in grey

🤖 Generated with [Claude Code](https://claude.com/claude-code)